### PR TITLE
ensure ck_decoder does not dispatch in test_attn_bias_padded

### DIFF
--- a/xformers/ops/fmha/ck_decoder.py
+++ b/xformers/ops/fmha/ck_decoder.py
@@ -57,6 +57,9 @@ class FwOp(AttentionFwOpBase):
             padding = attn_bias.k_seqinfo.padding
             bsz = d.key.shape[1] // padding
             num_queries = d.query.shape[1] // bsz
+            
+            if q_starts != list(range(0, 1 + bsz, num_queries)):
+                reasons.append("expect to have same num_queries in each batch")
             if bsz != len(q_starts) - 1:
                 reasons.append("empty lanes not supported yet")
 


### PR DESCRIPTION
Because the inputs have different num_queries per batch and it's not a supported case for ck decoder op