### PR TITLE
split-k decoder: move all tunable parameters to the top of cpp file

### DIFF
--- a/xformers/benchmarks/benchmark_attn_decoding.py
+++ b/xformers/benchmarks/benchmark_attn_decoding.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import sys
-from typing import Any, Type
+from typing import Any, Dict, Type
 
 import torch
 from torch.utils import benchmark
@@ -127,7 +127,7 @@ class AttentionDecodingPyTorchRepeat(AttentionDecodingFlashDecoding):
         return attn @ v
 
 
-BENCHMARKS: dict[str, Type[AttentionDecodingFlashDecoding]] = {
+BENCHMARKS: Dict[str, Type[AttentionDecodingFlashDecoding]] = {
     "pytorch": AttentionDecodingPyTorchRepeat,
 }
 

--- a/xformers/csrc/attention/hip_fmha/CMakeLists.txt
+++ b/xformers/csrc/attention/hip_fmha/CMakeLists.txt
@@ -19,7 +19,7 @@ set(project_root_dir /xformers)
 set(xformers_csrc ${project_root_dir}/xformers/csrc)
 set(sources ${xformers_csrc}/attention/hip_fmha/attention_forward_decoder.hip)
 set(splitk_sources ${xformers_csrc}/attention/hip_fmha/attention_forward_splitk.hip)
-set(ck_include ${project_root_dir}/third_party/composable_kernel/include/)
+set(ck_include ${project_root_dir}/third_party/composable_kernel_tiled/include/)
 set(torch_include /opt/conda/envs/py_${py_version}/lib/python${py_version}/site-packages/torch/include)
 
 set_source_files_properties(${sources} ${splitk_sources} PROPERTIES LANGUAGE HIP)

--- a/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder_splitk.h
+++ b/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder_splitk.h
@@ -622,22 +622,22 @@ struct FMHADecoderSplitKDeviceOp : public BaseOperator {
                     KV_M_MAX,
                     compute_t>
               : Q_size_k_alignment_necessary == 2
-                  ? efficient_attention_forward_decoder_splitk_ck_kernel<
-                        scalar_t,
-                        /* vec_size */ 2,
-                        n_loop_unroll,
-                        n_loop_unroll_tail,
-                        KV_M_MAX,
-                        compute_t>
-                  : Q_size_k_alignment_necessary == 1
-                      ? efficient_attention_forward_decoder_splitk_ck_kernel<
-                            scalar_t,
-                            /* vec_size */ 1,
-                            n_loop_unroll,
-                            n_loop_unroll_tail,
-                            KV_M_MAX,
-                            compute_t>
-                      : nullptr,
+              ? efficient_attention_forward_decoder_splitk_ck_kernel<
+                    scalar_t,
+                    /* vec_size */ 2,
+                    n_loop_unroll,
+                    n_loop_unroll_tail,
+                    KV_M_MAX,
+                    compute_t>
+              : Q_size_k_alignment_necessary == 1
+              ? efficient_attention_forward_decoder_splitk_ck_kernel<
+                    scalar_t,
+                    /* vec_size */ 1,
+                    n_loop_unroll,
+                    n_loop_unroll_tail,
+                    KV_M_MAX,
+                    compute_t>
+              : nullptr,
           arg.grid_dim,
           arg.block_dim,
           arg.lds_bytes,


### PR DESCRIPTION
The perf results are mixed and the kernel is being tuned