### PR TITLE
roll back fmha/common.py

### DIFF
--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -2242,7 +2242,9 @@ def test_forward_splitk(
 
 @cuda_only
 @pytest.mark.parametrize(
-    "op", [fmha.triton_splitk.FwOp, fmha.flash.FwOp, fmha.ck.FwOp], ids=lambda op: op.NAME
+    "op",
+    [fmha.triton_splitk.FwOp, fmha.flash.FwOp, fmha.ck.FwOp],
+    ids=lambda op: op.NAME,
 )
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=str)
 @pytest.mark.parametrize(

--- a/xformers/ops/fmha/common.py
+++ b/xformers/ops/fmha/common.py
@@ -180,13 +180,11 @@ class Inputs:
                 and self.value.shape == (B, Mkv, Kv)
             )
         H = self.query.shape[-2]
-        Hkv = self.key.shape[-2]
         if self.query.ndim == 4:  # BMHK
             valid_shapes = (
                 self.query.shape == (B, Mq, H, K)
-                and self.key.shape == (B, Mkv, Hkv, key_embed_dim)
-                and self.value.shape == (B, Mkv, Hkv, Kv)
-                and H % Hkv == 0
+                and self.key.shape == (B, Mkv, H, key_embed_dim)
+                and self.value.shape == (B, Mkv, H, Kv)
             )
         G = self.query.shape[2]
         if self.query.ndim == 5:  # BMNHK


### PR DESCRIPTION
Addressing
> The current interface of MHA is that H has to always match between qkv. If you want to do GQA - e.g. one kv-head for every n q-heads, you have to send 5D inputs. (Thus we're forcing the user to be very explicit.) Do we really want to relax that rule in this PR?

And also merging `test_mqa_forward` into `test_mqa_decoding` as suggested in

> To follow up on @bottler's question about @rocm_only - it'd be better for fmha.ck.FwOp to be covered by the generic test_forward and test_mqa_decoding. Then we don't need a separate test function (and eventually won't need @rocm_only after all such cases are refactored)

> Not sure if this should be blocking the merge or can be done as a follow-up