### PR TITLE
fix build: stream type

### DIFF
--- a/xformers/csrc/attention/hip_decoder/attention_forward_decoder.cpp
+++ b/xformers/csrc/attention/hip_decoder/attention_forward_decoder.cpp
@@ -96,7 +96,7 @@ at::Tensor& efficient_attention_forward_decoder_ck_out_impl(
   int32_t smem_output = K_MAX * sizeof(float) *
       threads.y; // 4 * threadsPerBlock * sizeof(float) == sizeof(O[b][0][h][:])
   const size_t lds_bytes = max(smem_softmax, smem_output);
-  auto stream = at::cuda::getCurrentHIPStream().stream();
+  auto stream = at::hip::getCurrentHIPStream().stream();
 
   AT_DISPATCH_SWITCH_3(
       at::ScalarType::Half,

--- a/xformers/csrc/attention/hip_decoder/attention_forward_splitk.cpp
+++ b/xformers/csrc/attention/hip_decoder/attention_forward_splitk.cpp
@@ -139,7 +139,7 @@ at::Tensor& efficient_attention_forward_decoder_splitk_ck_out_impl(
       WavefrontsPerBlock; // 4 * threadsPerBlock * sizeof(float) ==
                           // sizeof(O[b][0][h][:])
   const size_t attn_lds_bytes = max(smem_softmax, smem_output);
-  auto stream = at::cuda::getCurrentHIPStream().stream();
+  auto stream = at::hip::getCurrentHIPStream().stream();
 
   AT_DISPATCH_SWITCH_3(
       at::ScalarType::Half,

--- a/xformers/csrc/attention/hip_fmha/attention_backward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_backward_generic_ck_tiled.cpp
@@ -111,8 +111,7 @@ efficient_attention_backward_ck(
     TORCH_CHECK(max_seqlen_k_.has_value());
   }
 
-  // at::cuda::CUDAGuard device_guard(query.device());
-  hipStream_t stream = at::cuda::getCurrentHIPStream().stream();
+  hipStream_t stream = at::hip::getCurrentHIPStream().stream();
 
   int64_t B = query.size(0);
   int64_t M = query.size(1);

--- a/xformers/csrc/attention/hip_fmha/attention_ck_rand_uniform.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_ck_rand_uniform.cpp
@@ -33,8 +33,7 @@ at::Tensor rand_uniform_int(
   int M = out_pattern.size(2);
   int N = out_pattern.size(3);
 
-  // at::cuda::CUDAGuard device_guard(out_pattern.device());
-  hipStream_t stream = at::cuda::getCurrentHIPStream().stream();
+  hipStream_t stream = at::hip::getCurrentHIPStream().stream();
 
   at::CUDAGeneratorImpl* gen =
       at::get_generator_or_default<at::CUDAGeneratorImpl>(

--- a/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
@@ -105,8 +105,7 @@ efficient_attention_forward_ck(
   CHECK_NOSPARSE_LASTCONTIGUOUS_CUDA(key);
   CHECK_NOSPARSE_LASTCONTIGUOUS_CUDA(value);
 
-  // at::cuda::CUDAGuard device_guard(query.device());
-  hipStream_t stream = at::cuda::getCurrentHIPStream().stream();
+  hipStream_t stream = at::hip::getCurrentHIPStream().stream();
 
   int64_t B = query.size(0);
   int64_t M = query.size(1);


### PR DESCRIPTION
```
#9 24.95 /opt/xformers/xformers/csrc/attention/hip_decoder/attention_forward_decoder.hip:100:27: error: no member named 'getCurrentHIPStream' in namespace 'at::cuda'; did you mean 'getCurrentCUDAStream'?
#9 24.95   100 |   auto stream = at::cuda::getCurrentHIPStream().stream();
#9 24.95       |                 ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
#9 24.95       |                           getCurrentCUDAStream
#9 24.95 /.venv/lib/python3.11/site-packages/torch/include/c10/hip/HIPStream.h:244:20: note: 'getCurrentCUDAStream' declared here
#9 24.95   244 | C10_API CUDAStream getCurrentCUDAStream(DeviceIndex device_index = -1);
#9 24.95       |                    ^
```