### PR TITLE
Fwd hd96 debug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "third_party/composable_kernel_tiled"]
 	path = third_party/composable_kernel_tiled
 	url = https://github.com/ROCm/composable_kernel.git
-	branch = fwd_hd96_debug 
+	branch = develop 

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "third_party/composable_kernel_tiled"]
 	path = third_party/composable_kernel_tiled
 	url = https://github.com/ROCm/composable_kernel.git
-	branch = develop
+	branch = fwd_hd96_debug 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_dispatch.h
@@ -62,8 +62,7 @@ struct batched_forward_causalmask_bias_dropout_dispatch {
       const bool pad_seqlen_q = !(param.M % FmhaFwdShape_::kM0 == 0);
       const bool pad_seqlen_k =
           (param.N == 0) || !(param.N % FmhaFwdShape_::kN0 == 0);
-      const bool pad_headdim_q =
-          !(param.K % FmhaFwdShape_::kK0BlockLength == 0);
+      const bool pad_headdim_q = !(param.K % FmhaFwdShape_::kSubQKHeaddim == 0);
       const bool pad_headdim_v = !(param.Kv % FmhaFwdShape_::kN1 == 0);
 
       // usually headdim_q and headdim_v are same, consider them together to

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_dispatch.h
@@ -79,7 +79,7 @@ struct batched_forward_splitkv_causalmask_bias_dropout_dispatch {
         const bool pad_seqlen_q = !(param.M % FmhaTileShape::kM0 == 0);
         const bool pad_headdim_v = !(param.Kv % FmhaTileShape::kN1 == 0);
         const bool pad_headdim_q =
-            !(param.K % FmhaTileShape::kK0BlockLength == 0);
+            !(param.K % FmhaTileShape::kSubQKHeaddim == 0);
 
         // usually headdim_q and headdim_v are same, consider them together to
         // determine whether to do padding saving some compiling time

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_dispatch.h
@@ -63,7 +63,7 @@ struct batched_infer_causalmask_bias_dropout_dispatch {
       const bool pad_seqlen_k =
           (param.N == 0) || !(param.N % FmhaShape::kN0 == 0);
       const bool pad_headdim_v = !(param.Kv % FmhaShape::kN1 == 0);
-      const bool pad_headdim_q = !(param.K % FmhaShape::kK0BlockLength == 0);
+      const bool pad_headdim_q = !(param.K % FmhaShape::kSubQKHeaddim == 0);
 
       // usually headdim_q and headdim_v are same, consider them together to
       // determine whether to do padding saving some compiling time

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_dispatch.h
@@ -79,7 +79,7 @@ struct batched_infer_splitkv_causalmask_bias_dropout_dispatch {
         const bool pad_seqlen_q = !(param.M % FmhaTileShape::kM0 == 0);
         const bool pad_headdim_v = !(param.Kv % FmhaTileShape::kN1 == 0);
         const bool pad_headdim_q =
-            !(param.K % FmhaTileShape::kK0BlockLength == 0);
+            !(param.K % FmhaTileShape::kSubQKHeaddim == 0);
 
         // usually headdim_q and headdim_v are same, consider them together to
         // determine whether to do padding saving some compiling time

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_setting.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_setting.h
@@ -63,6 +63,13 @@ struct FmhaFwdBlockTile<64> {
 };
 
 template <>
+struct FmhaFwdBlockTile<96> {
+  using type = ck_tile::sequence<128, 128, 32, 128, 32, 96>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<4, 1, 1>;
+};
+
+template <>
 struct FmhaFwdBlockTile<128> {
   using type = ck_tile::sequence<128, 128, 32, 128, 32, 128>;
   using gemm0_warps = ck_tile::sequence<4, 1, 1>;
@@ -98,6 +105,15 @@ struct FmhaFwdShape<64> : ck_tile::TileFmhaShape<
                               typename FmhaFwdBlockTile<64>::gemm0_warps,
                               FmhaFwdWarpTile,
                               typename FmhaFwdBlockTile<64>::gemm1_warps,
+                              FmhaFwdWarpTile,
+                              IsVLayoutRowMajor> {};
+
+template <>
+struct FmhaFwdShape<96> : ck_tile::TileFmhaShape<
+                              typename FmhaFwdBlockTile<96>::type,
+                              typename FmhaFwdBlockTile<96>::gemm0_warps,
+                              FmhaFwdWarpTile,
+                              typename FmhaFwdBlockTile<96>::gemm1_warps,
                               FmhaFwdWarpTile,
                               IsVLayoutRowMajor> {};
 
@@ -139,6 +155,15 @@ struct FmhaFwdSplitKVBlockTile<64, MaxSeqlenQ> {
 };
 
 template struct FmhaFwdSplitKVBlockTile<64>;
+
+template <ck_tile::index_t MaxSeqlenQ>
+struct FmhaFwdSplitKVBlockTile<96, MaxSeqlenQ> {
+  using type = ck_tile::sequence<64, 128, 32, 128, 32, 96>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<4, 1, 1>;
+};
+
+template struct FmhaFwdSplitKVBlockTile<96>;
 
 template <>
 struct FmhaFwdSplitKVBlockTile<128, 32> {
@@ -195,6 +220,20 @@ struct FmhaFwdSplitKVShape<64, MaxSeqlenQ> {
 
 template struct FmhaFwdSplitKVShape<64, 32>;
 template struct FmhaFwdSplitKVShape<64, 64>;
+
+template <ck_tile::index_t MaxSeqlenQ>
+struct FmhaFwdSplitKVShape<96, MaxSeqlenQ> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVBlockTile<96>::type,
+      typename FmhaFwdSplitKVBlockTile<96>::gemm0_warps,
+      FmhaFwdSplitKVWarpTile,
+      typename FmhaFwdSplitKVBlockTile<96, MaxSeqlenQ>::gemm1_warps,
+      FmhaFwdSplitKVWarpTile,
+      IsVLayoutRowMajor>;
+};
+
+template struct FmhaFwdSplitKVShape<96, 32>;
+template struct FmhaFwdSplitKVShape<96, 64>;
 
 template <>
 struct FmhaFwdSplitKVShape<128, 32> {

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_dispatch.h
@@ -62,8 +62,7 @@ struct grouped_forward_causalmask_bias_dropout_dispatch {
       constexpr bool kPadSeqLenQ = true;
       constexpr bool kPadSeqLenK = true;
 
-      const bool pad_headdim_q =
-          !(param.K % FmhaFwdShape_::kK0BlockLength == 0);
+      const bool pad_headdim_q = !(param.K % FmhaFwdShape_::kSubQKHeaddim == 0);
       const bool pad_headdim_v = !(param.Kv % FmhaFwdShape_::kN1 == 0);
 
       BOOL_SWITCH_2(

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_dispatch.h
@@ -81,7 +81,7 @@ struct grouped_forward_splitkv_causalmask_bias_dropout_dispatch {
         constexpr bool kPadSeqLenK = true;
 
         const bool pad_headdim_q =
-            !(param.K % FmhaTileShape::kK0BlockLength == 0);
+            !(param.K % FmhaTileShape::kSubQKHeaddim == 0);
         const bool pad_headdim_v = !(param.Kv % FmhaTileShape::kN1 == 0);
 
         BOOL_SWITCH_2(

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
@@ -61,7 +61,7 @@ struct grouped_infer_causalmask_bias_dropout_dispatch {
       constexpr bool kPadSeqLenQ = true;
       constexpr bool kPadSeqLenK = true;
 
-      bool pad_headdim_q = !(param.K % FmhaShape::kK0BlockLength == 0);
+      bool pad_headdim_q = !(param.K % FmhaShape::kSubQKHeaddim == 0);
       bool pad_headdim_v = !(param.Kv % FmhaShape::kN1 == 0);
       const bool use_async_pipeline =
           (!kHasBias && (param.K % 8 == 0) && (param.Kv % 8 == 0) &&

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_dispatch.h
@@ -80,7 +80,7 @@ struct grouped_infer_splitkv_causalmask_bias_dropout_dispatch {
         constexpr bool kPadSeqLenQ = true;
         constexpr bool kPadSeqLenK = true;
 
-        bool pad_headdim_q = !(param.K % FmhaTileShape::kK0BlockLength == 0);
+        bool pad_headdim_q = !(param.K % FmhaTileShape::kSubQKHeaddim == 0);
         bool pad_headdim_v = !(param.Kv % FmhaTileShape::kN1 == 0);
 
         BOOL_SWITCH_2(

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
@@ -23,6 +23,9 @@
     } else if (HEAD_DIM1 <= 64 && HEAD_DIM2 <= 64) {                   \
       constexpr ck_tile::index_t CONST_NAME = 64;                      \
       __VA_ARGS__();                                                   \
+    } else if (HEAD_DIM1 <= 96 && HEAD_DIM2 <= 96) {                   \
+      constexpr ck_tile::index_t CONST_NAME = 96;                      \
+      __VA_ARGS__();                                                   \
     } else if (HEAD_DIM1 <= 128 && HEAD_DIM2 <= 128) {                 \
       constexpr ck_tile::index_t CONST_NAME = 128;                     \
       __VA_ARGS__();                                                   \
@@ -59,6 +62,9 @@
       __VA_ARGS__();                                                   \
     } else if (HEAD_DIM1 <= 64 && HEAD_DIM2 <= 64) {                   \
       constexpr ck_tile::index_t CONST_NAME = 64;                      \
+      __VA_ARGS__();                                                   \
+    } else if (HEAD_DIM1 <= 96 && HEAD_DIM2 <= 96) {                   \
+      constexpr ck_tile::index_t CONST_NAME = 96;                      \
       __VA_ARGS__();                                                   \
     } else if (HEAD_DIM1 <= 128 && HEAD_DIM2 <= 128) {                 \
       constexpr ck_tile::index_t CONST_NAME = 128;                     \

--- a/xformers/csrc/attention/hip_fmha/generate_instances.py
+++ b/xformers/csrc/attention/hip_fmha/generate_instances.py
@@ -369,10 +369,10 @@ if __name__ == "__main__":
             disable_hd256 = True
 
     if disable_hd256:
-        headdims_fwd = [32, 64, 128]
+        headdims_fwd = [32, 64, 96, 128]
         headdims_bwd = [32, 64, 96, 128]
     else:
-        headdims_fwd = [32, 64, 128, 256]
+        headdims_fwd = [32, 64, 96, 128, 256]
         headdims_bwd = [32, 64, 96, 128, 256]
 
     this_dir = os.path.dirname(__file__)

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_instances_ref.h
@@ -128,6 +128,62 @@ extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
     true,
     true,
     true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
     128>(BatchedForwardParams& param, hipStream_t stream);
 
 extern template void run_batched_forward_causalmask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_instances_ref.h
@@ -128,6 +128,62 @@ extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
     true,
     true,
     true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
     128>(BatchedForwardParams& param, hipStream_t stream);
 
 extern template void run_batched_forward_causalmask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_instances_ref.h
@@ -128,6 +128,62 @@ extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
     true,
     true,
     true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
     128>(BatchedForwardParams& param, hipStream_t stream);
 
 extern template void run_batched_infer_causalmask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_instances_ref.h
@@ -128,6 +128,62 @@ extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
     true,
     true,
     true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
     128>(BatchedForwardParams& param, hipStream_t stream);
 
 extern template void run_batched_infer_causalmask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    96>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_instances_ref.h
@@ -128,6 +128,62 @@ extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
     true,
     true,
     true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
     128>(GroupedForwardParams& param, hipStream_t stream);
 
 extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_instances_ref.h
@@ -128,6 +128,62 @@ extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
     true,
     true,
     true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
     128>(GroupedForwardParams& param, hipStream_t stream);
 
 extern template void run_grouped_forward_causalmask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_instances_ref.h
@@ -128,6 +128,62 @@ extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
     true,
     true,
     true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
     128>(GroupedForwardParams& param, hipStream_t stream);
 
 extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_instances_ref.h
@@ -128,6 +128,62 @@ extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
     true,
     true,
     true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
     128>(GroupedForwardParams& param, hipStream_t stream);
 
 extern template void run_grouped_infer_causalmask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_causalmask_has_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_causalmask_has_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_causalmask_no_bias_has_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_causalmask_no_bias_no_dropout_maxk_96.cpp
@@ -1,0 +1,19 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_causalmask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    96>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/ops/fmha/ck.py
+++ b/xformers/ops/fmha/ck.py
@@ -187,6 +187,7 @@ class FwOp(AttentionFwOpBase):
 
     _TEST_K: List[int] = [
         32,  # 64x64 kernel
+        96,
         128,  # 64x128 kernel
         256,  # 64x128 with accumulation in gmem
     ]


### PR DESCRIPTION
This PR add changes and new instances to support fmha-fwd headdim96, which makes running headdim96 cases faster than using headdim128