### PR TITLE
[CK] Memory-efficient attention (Head Dimension = 512)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -422,6 +422,14 @@ def get_extensions():
     elif torch.version.hip and (
         torch.cuda.is_available() or os.getenv("HIP_ARCHITECTURES", "") != ""
     ):
+        enable_hd512_hip_fmha = os.getenv("ENABLE_HD512_HIP_FMHA", "0")
+        if enable_hd512_hip_fmha != "1":
+            source_hip_maxk_512 = []
+            for ff in source_hip:
+                if ff.endswith("maxk_512.cpp"):
+                    source_hip_maxk_512 += [ff]
+            source_hip = list(set(source_hip) - set(source_hip_maxk_512))
+
         rename_cpp_cu(source_hip)
         hip_version = get_hip_version(ROCM_HOME)
 
@@ -441,6 +449,8 @@ def get_extensions():
         ]
 
         generator_flag = []
+        if enable_hd512_hip_fmha == "1":
+            generator_flag += ["-DFMHA_LIMIT_MAX_HEADDIM_TO_256=0"]
 
         cc_flag = ["-DBUILD_PYTHON_PACKAGE"]
         use_rtn_bf16_convert = os.getenv("ENABLE_HIP_FMHA_RTN_BF16_CONVERT", "0")

--- a/setup.py
+++ b/setup.py
@@ -422,14 +422,6 @@ def get_extensions():
     elif torch.version.hip and (
         torch.cuda.is_available() or os.getenv("HIP_ARCHITECTURES", "") != ""
     ):
-        disable_hd256_hip_fmha = os.getenv("DISABLE_HD256_HIP_FMHA", "0")
-        if disable_hd256_hip_fmha == "1":
-            source_hip_maxk_256 = []
-            for ff in source_hip:
-                if ff.endswith("maxk_256.cpp"):
-                    source_hip_maxk_256 += [ff]
-            source_hip = list(set(source_hip) - set(source_hip_maxk_256))
-
         rename_cpp_cu(source_hip)
         hip_version = get_hip_version(ROCM_HOME)
 
@@ -449,8 +441,6 @@ def get_extensions():
         ]
 
         generator_flag = []
-        if disable_hd256_hip_fmha == "1":
-            generator_flag += ["-DFMHA_SUPPORT_MAX_HEADDIM_128=1"]
 
         cc_flag = ["-DBUILD_PYTHON_PACKAGE"]
         use_rtn_bf16_convert = os.getenv("ENABLE_HIP_FMHA_RTN_BF16_CONVERT", "0")

--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -462,6 +462,16 @@ def test_forward(opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, packed, fmt, **kwargs)
     if fmt == "BMK" and not fmha.common._is_bias_type_supported_in_BMK(bias_type):
         pytest.skip("BMK incompatible with this bias")
 
+    if op is fmha.ck.FwOp:
+        if (k > 256 or kv > 256) and issubclass(
+            bias_type,
+            (
+                fmha.attn_bias.PagedBlockDiagonalPaddedKeysMask,
+                fmha.attn_bias.PagedBlockDiagonalGappyKeysMask,
+            ),
+        ):
+            pytest.skip("ck.FwOp hdim-512 is not supported when Paged-KVCache is used!")
+
     query, key, value, attn_bias = create_tensors(
         *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
         fmt="BMHK" if packed else fmt,

--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -472,6 +472,11 @@ def test_forward(opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv, packed, fmt, **kwargs)
         ):
             pytest.skip("ck.FwOp hdim-512 is not supported when Paged-KVCache is used!")
 
+    # comment this for testing hdim-512 cases if hdim-512 support is built into hip_fmha
+    if op is fmha.ck.FwOp:
+        if k > 256 or kv > 256:
+            pytest.skip("ck.FwOp hdim-512 support is not built by default!")
+
     query, key, value, attn_bias = create_tensors(
         *opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv,
         fmt="BMHK" if packed else fmt,

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
@@ -34,11 +34,11 @@ void run_batched_forward_mask_bias_dropout_dispatch(
         });
       } else {
         batched_forward_mask_bias_dropout_dispatch<
-          ScalarType,
-          kHasMask,
-          kHasBias,
-          kHasDropout,
-          MaxK>::Run(param, stream);
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK>::Run(param, stream);
       }
     } else
 #endif

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
@@ -23,33 +23,30 @@ template <
 void run_batched_forward_mask_bias_dropout_dispatch(
     BatchedForwardParams& param,
     hipStream_t stream) {
-  if constexpr (MaxK > 256) {
-    batched_forward_mask_bias_dropout_dispatch<
-            ScalarType,
-            kHasMask,
-            kHasBias,
-            kHasDropout,
-            MaxK,
-            128>::Run(param, stream);
-  } else
-  // currently split-kv implementation does not support dropout
+  // currently split-kv implementation does not support: 
+  // (*) dropout
+  // (*) head dimension > 256 
   if constexpr (!kHasDropout) {
-    if (param.use_split_kv) {
-      if (use_splitkv_smallq(param.M, std::max(param.K, param.Kv))) {
-        batched_forward_splitkv_smallq_mask_bias_dropout_dispatch<
-            ScalarType,
-            kHasMask,
-            kHasBias,
-            MaxK>::Run(param, stream);
-      } else {
-        FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
-          batched_forward_splitkv_mask_bias_dropout_dispatch<
+    if (param.use_split_kv && MaxK <= 256) {
+      if constexpr (MaxK <= 256) {
+        if (use_splitkv_smallq(param.M, std::max(param.K, param.Kv))) {
+          batched_forward_splitkv_smallq_mask_bias_dropout_dispatch<
               ScalarType,
               kHasMask,
               kHasBias,
-              MaxK,
-              MaxSeqlenQ>::Run(param, stream);
-        });
+              MaxK>::Run(param, stream);
+        } else {
+          FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
+            batched_forward_splitkv_mask_bias_dropout_dispatch<
+                ScalarType,
+                kHasMask,
+                kHasBias,
+                MaxK,
+                MaxSeqlenQ>::Run(param, stream);
+          });
+        }
+      } else {
+        // Unreachable. Do not instantiate split-kv pipelines with head dimension > 256
       }
     } else {
       if (get_fmha_fwd_mtile(param.B, param.Hq, param.M) == 128)

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
@@ -23,9 +23,9 @@ template <
 void run_batched_forward_mask_bias_dropout_dispatch(
     BatchedForwardParams& param,
     hipStream_t stream) {
-  // currently split-kv implementation does not support: 
+  // currently split-kv implementation does not support:
   // (*) dropout
-  // (*) head dimension > 256 
+  // (*) head dimension > 256
   if constexpr (!kHasDropout) {
     if (param.use_split_kv && MaxK <= 256) {
       if constexpr (MaxK <= 256) {
@@ -46,7 +46,8 @@ void run_batched_forward_mask_bias_dropout_dispatch(
           });
         }
       } else {
-        // Unreachable. Do not instantiate split-kv pipelines with head dimension > 256
+        // Unreachable. Do not instantiate split-kv pipelines with head
+        // dimension > 256
       }
     } else {
       if (get_fmha_fwd_mtile(param.B, param.Hq, param.M) == 128)

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
@@ -24,14 +24,21 @@ void run_batched_forward_mask_bias_dropout_dispatch(
 #ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
       if constexpr (MaxK <= 256) {
-      FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
-        batched_forward_splitkv_mask_bias_dropout_dispatch<
-            ScalarType,
-            kHasMask,
-            kHasBias,
-            MaxK,
-            MaxSeqlenQ>::Run(param, stream);
-      });
+        FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
+          batched_forward_splitkv_mask_bias_dropout_dispatch<
+              ScalarType,
+              kHasMask,
+              kHasBias,
+              MaxK,
+              MaxSeqlenQ>::Run(param, stream);
+        });
+      } else {
+        batched_forward_mask_bias_dropout_dispatch<
+          ScalarType,
+          kHasMask,
+          kHasBias,
+          kHasDropout,
+          MaxK>::Run(param, stream);
       }
     } else
 #endif

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
@@ -23,6 +23,7 @@ void run_batched_forward_mask_bias_dropout_dispatch(
   if constexpr (!kHasDropout) {
 #ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
+      if constexpr (MaxK <= 256) {
       FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
         batched_forward_splitkv_mask_bias_dropout_dispatch<
             ScalarType,
@@ -31,6 +32,7 @@ void run_batched_forward_mask_bias_dropout_dispatch(
             MaxK,
             MaxSeqlenQ>::Run(param, stream);
       });
+      }
     } else
 #endif
       batched_forward_mask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_dispatch.h
@@ -48,7 +48,7 @@ struct batched_forward_mask_bias_dropout_dispatch {
     using FmhaFwdTilePartitioner_ =
         ck_tile::FmhaFwdTilePartitioner<FmhaFwdShape_>;
     constexpr ck_tile::index_t occupancy =
-        (MaxK == 64) ? 3 : ((MaxK == 256) ? 1 : 2);
+        (MaxK == 64) ? 3 : ((MaxK >= 256) ? 1 : 2);
 
     constexpr auto kBiasEnum = kHasBias
         ? ck_tile::BlockAttentionBiasEnum::ELEMENTWISE_BIAS

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
@@ -23,33 +23,30 @@ template <
 void run_batched_infer_mask_bias_dropout_dispatch(
     BatchedForwardParams& param,
     hipStream_t stream) {
-  if constexpr (MaxK > 256) {
-    batched_infer_mask_bias_dropout_dispatch<
-        ScalarType,
-        kHasMask,
-        kHasBias,
-        kHasDropout,
-        MaxK,
-        128>::Run(param, stream);
-  } else
-  // currently split-kv implementation does not support dropout
+  // currently split-kv implementation does not support: 
+  // (*) dropout
+  // (*) head dimension > 256  
   if constexpr (!kHasDropout) {
-    if (param.use_split_kv) {
-      if (use_splitkv_smallq(param.M, std::max(param.K, param.Kv))) {
-        batched_infer_splitkv_smallq_mask_bias_dropout_dispatch<
-            ScalarType,
-            kHasMask,
-            kHasBias,
-            MaxK>::Run(param, stream);
-      } else {
-        FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
-          batched_infer_splitkv_mask_bias_dropout_dispatch<
+    if (param.use_split_kv && MaxK <= 256) {
+      if constexpr (MaxK <= 256) {
+        if (use_splitkv_smallq(param.M, std::max(param.K, param.Kv))) {
+          batched_infer_splitkv_smallq_mask_bias_dropout_dispatch<
               ScalarType,
               kHasMask,
               kHasBias,
-              MaxK,
-              MaxSeqlenQ>::Run(param, stream);
-        });
+              MaxK>::Run(param, stream);
+        } else {
+          FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
+            batched_infer_splitkv_mask_bias_dropout_dispatch<
+                ScalarType,
+                kHasMask,
+                kHasBias,
+                MaxK,
+                MaxSeqlenQ>::Run(param, stream);
+          });
+        }
+      } else {
+        // Unreachable. Do not instantiate split-kv pipelines with head dimension > 256
       }
     } else {
       if (get_fmha_fwd_mtile(param.B, param.Hq, param.M) == 128)

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
@@ -23,6 +23,7 @@ void run_batched_infer_mask_bias_dropout_dispatch(
   if constexpr (!kHasDropout) {
 #ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
+    if constexpr (MaxK <= 256) {
       FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
         batched_infer_splitkv_mask_bias_dropout_dispatch<
             ScalarType,
@@ -31,6 +32,7 @@ void run_batched_infer_mask_bias_dropout_dispatch(
             MaxK,
             MaxSeqlenQ>::Run(param, stream);
       });
+    }
     } else
 #endif
       batched_infer_mask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
@@ -23,9 +23,9 @@ template <
 void run_batched_infer_mask_bias_dropout_dispatch(
     BatchedForwardParams& param,
     hipStream_t stream) {
-  // currently split-kv implementation does not support: 
+  // currently split-kv implementation does not support:
   // (*) dropout
-  // (*) head dimension > 256  
+  // (*) head dimension > 256
   if constexpr (!kHasDropout) {
     if (param.use_split_kv && MaxK <= 256) {
       if constexpr (MaxK <= 256) {
@@ -46,7 +46,8 @@ void run_batched_infer_mask_bias_dropout_dispatch(
           });
         }
       } else {
-        // Unreachable. Do not instantiate split-kv pipelines with head dimension > 256
+        // Unreachable. Do not instantiate split-kv pipelines with head
+        // dimension > 256
       }
     } else {
       if (get_fmha_fwd_mtile(param.B, param.Hq, param.M) == 128)

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
@@ -34,11 +34,11 @@ void run_batched_infer_mask_bias_dropout_dispatch(
         });
       } else {
         batched_infer_mask_bias_dropout_dispatch<
-          ScalarType,
-          kHasMask,
-          kHasBias,
-          kHasDropout,
-          MaxK>::Run(param, stream);
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK>::Run(param, stream);
       }
     } else
 #endif

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
@@ -23,16 +23,23 @@ void run_batched_infer_mask_bias_dropout_dispatch(
   if constexpr (!kHasDropout) {
 #ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
-    if constexpr (MaxK <= 256) {
-      FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
-        batched_infer_splitkv_mask_bias_dropout_dispatch<
-            ScalarType,
-            kHasMask,
-            kHasBias,
-            MaxK,
-            MaxSeqlenQ>::Run(param, stream);
-      });
-    }
+      if constexpr (MaxK <= 256) {
+        FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
+          batched_infer_splitkv_mask_bias_dropout_dispatch<
+              ScalarType,
+              kHasMask,
+              kHasBias,
+              MaxK,
+              MaxSeqlenQ>::Run(param, stream);
+        });
+      } else {
+        batched_infer_mask_bias_dropout_dispatch<
+          ScalarType,
+          kHasMask,
+          kHasBias,
+          kHasDropout,
+          MaxK>::Run(param, stream);
+      }
     } else
 #endif
       batched_infer_mask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_dispatch.h
@@ -48,7 +48,7 @@ struct batched_infer_mask_bias_dropout_dispatch {
     using FmhaShape = FmhaFwdShape<MaxK>;
     using FmhaTilePartitioner = ck_tile::FmhaFwdTilePartitioner<FmhaShape>;
     constexpr ck_tile::index_t occupancy =
-        (MaxK == 64) ? 3 : ((MaxK == 256) ? 1 : 2);
+        (MaxK == 64) ? 3 : ((MaxK >= 256) ? 1 : 2);
 
     constexpr auto kBiasEnum = kHasBias
         ? ck_tile::BlockAttentionBiasEnum::ELEMENTWISE_BIAS

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_setting.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_setting.h
@@ -83,6 +83,13 @@ struct FmhaFwdBlockTile<256> {
   using gemm1_warps = ck_tile::sequence<4, 1, 1>;
 };
 
+template <>
+struct FmhaFwdBlockTile<512> {
+  using type = ck_tile::sequence<128, 128, 32, 512, 32, 512>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<4, 1, 1>;
+};
+
 using FmhaFwdWarpTile = ck_tile::sequence<32, 32, 16>;
 
 static constexpr bool IsVLayoutRowMajor = true;
@@ -132,6 +139,15 @@ struct FmhaFwdShape<256> : ck_tile::TileFmhaShape<
                                typename FmhaFwdBlockTile<256>::gemm0_warps,
                                FmhaFwdWarpTile,
                                typename FmhaFwdBlockTile<256>::gemm1_warps,
+                               FmhaFwdWarpTile,
+                               IsVLayoutRowMajor> {};
+
+template <>
+struct FmhaFwdShape<512> : ck_tile::TileFmhaShape<
+                               typename FmhaFwdBlockTile<512>::type,
+                               typename FmhaFwdBlockTile<512>::gemm0_warps,
+                               FmhaFwdWarpTile,
+                               typename FmhaFwdBlockTile<512>::gemm1_warps,
                                FmhaFwdWarpTile,
                                IsVLayoutRowMajor> {};
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_setting.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_setting.h
@@ -204,6 +204,15 @@ struct FmhaFwdSplitKVBlockTile<256, MaxSeqlenQ> {
 
 template struct FmhaFwdSplitKVBlockTile<256>;
 
+template <ck_tile::index_t MaxSeqlenQ>
+struct FmhaFwdSplitKVBlockTile<512, MaxSeqlenQ> {
+  using type = ck_tile::sequence<64, 128, 32, 512, 32, 512>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<4, 1, 1>;
+};
+
+template struct FmhaFwdSplitKVBlockTile<512>;
+
 using FmhaFwdSplitKVWarpTile = ck_tile::sequence<16, 16, 16>;
 
 template <ck_tile::index_t MaxK, ck_tile::index_t MaxSeqlenQ>
@@ -286,3 +295,17 @@ struct FmhaFwdSplitKVShape<256, MaxSeqlenQ> {
 
 template struct FmhaFwdSplitKVShape<256, 32>;
 template struct FmhaFwdSplitKVShape<256, 64>;
+
+template <ck_tile::index_t MaxSeqlenQ>
+struct FmhaFwdSplitKVShape<512, MaxSeqlenQ> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVBlockTile<512>::type,
+      typename FmhaFwdSplitKVBlockTile<512>::gemm0_warps,
+      FmhaFwdSplitKVWarpTile,
+      typename FmhaFwdSplitKVBlockTile<512>::gemm1_warps,
+      FmhaFwdSplitKVWarpTile,
+      IsVLayoutRowMajor>;
+};
+
+template struct FmhaFwdSplitKVShape<512, 32>;
+template struct FmhaFwdSplitKVShape<512, 64>;

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_selector.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_selector.h
@@ -47,6 +47,10 @@ static std::pair<bool, int> get_num_kv_splits_heuristic(
   mtile_size_for_splitkv_smallq =
       get_mtile_size_for_splitkv_smallq(max_headdim);
 
+  // hdim-512 is not supported by splitkv-kernel at present
+  if (max_headdim > 256)
+    return std::make_pair(false, 1);
+
   if (max_seqlen_q >= mtile_size_for_pipeline_default) {
     int batch_nhead_mblocks = num_batches * num_heads *
         ceildiv(max_seqlen_q, mtile_size_for_pipeline_default);

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
@@ -34,11 +34,11 @@ void run_grouped_forward_mask_bias_dropout_dispatch(
         });
       } else {
         grouped_forward_mask_bias_dropout_dispatch<
-          ScalarType,
-          kHasMask,
-          kHasBias,
-          kHasDropout,
-          MaxK>::Run(param, stream);
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK>::Run(param, stream);
       }
     } else
 #endif

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
@@ -23,33 +23,30 @@ template <
 void run_grouped_forward_mask_bias_dropout_dispatch(
     GroupedForwardParams& param,
     hipStream_t stream) {
-  if constexpr (MaxK > 256) {
-    grouped_forward_mask_bias_dropout_dispatch<
-        ScalarType,
-        kHasMask,
-        kHasBias,
-        kHasDropout,
-        MaxK,
-        128>::Run(param, stream);
-  } else
-  // currently split-kv implementation does not support dropout
+  // currently split-kv implementation does not support: 
+  // (*) dropout
+  // (*) head dimension > 256  
   if constexpr (!kHasDropout) {
-    if (param.use_split_kv) {
-      if (use_splitkv_smallq(param.max_seqlen_q, std::max(param.K, param.Kv))) {
-        grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch<
-            ScalarType,
-            kHasMask,
-            kHasBias,
-            MaxK>::Run(param, stream);
-      } else {
-        FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
-          grouped_forward_splitkv_mask_bias_dropout_dispatch<
+    if (param.use_split_kv && MaxK <= 256) {
+      if constexpr (MaxK <= 256) {
+        if (use_splitkv_smallq(param.max_seqlen_q, std::max(param.K, param.Kv))) {
+          grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch<
               ScalarType,
               kHasMask,
               kHasBias,
-              MaxK,
-              MaxSeqlenQ>::Run(param, stream);
-        });
+              MaxK>::Run(param, stream);
+        } else {
+          FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
+            grouped_forward_splitkv_mask_bias_dropout_dispatch<
+                ScalarType,
+                kHasMask,
+                kHasBias,
+                MaxK,
+                MaxSeqlenQ>::Run(param, stream);
+          });
+        }
+      } else {
+        // Unreachable. Do not instantiate split-kv pipelines with head dimension > 256
       }
     } else {
       if (get_fmha_fwd_mtile(param.num_batches, param.Hq, param.max_seqlen_q) ==

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
@@ -24,14 +24,21 @@ void run_grouped_forward_mask_bias_dropout_dispatch(
 #ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
       if constexpr (MaxK <= 256) {
-      FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
-        grouped_forward_splitkv_mask_bias_dropout_dispatch<
-            ScalarType,
-            kHasMask,
-            kHasBias,
-            MaxK,
-            MaxSeqlenQ>::Run(param, stream);
-      });
+        FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
+          grouped_forward_splitkv_mask_bias_dropout_dispatch<
+              ScalarType,
+              kHasMask,
+              kHasBias,
+              MaxK,
+              MaxSeqlenQ>::Run(param, stream);
+        });
+      } else {
+        grouped_forward_mask_bias_dropout_dispatch<
+          ScalarType,
+          kHasMask,
+          kHasBias,
+          kHasDropout,
+          MaxK>::Run(param, stream);
       }
     } else
 #endif

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
@@ -23,6 +23,7 @@ void run_grouped_forward_mask_bias_dropout_dispatch(
   if constexpr (!kHasDropout) {
 #ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
+      if constexpr (MaxK <= 256) {
       FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
         grouped_forward_splitkv_mask_bias_dropout_dispatch<
             ScalarType,
@@ -31,6 +32,7 @@ void run_grouped_forward_mask_bias_dropout_dispatch(
             MaxK,
             MaxSeqlenQ>::Run(param, stream);
       });
+      }
     } else
 #endif
       grouped_forward_mask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
@@ -23,13 +23,14 @@ template <
 void run_grouped_forward_mask_bias_dropout_dispatch(
     GroupedForwardParams& param,
     hipStream_t stream) {
-  // currently split-kv implementation does not support: 
+  // currently split-kv implementation does not support:
   // (*) dropout
-  // (*) head dimension > 256  
+  // (*) head dimension > 256
   if constexpr (!kHasDropout) {
     if (param.use_split_kv && MaxK <= 256) {
       if constexpr (MaxK <= 256) {
-        if (use_splitkv_smallq(param.max_seqlen_q, std::max(param.K, param.Kv))) {
+        if (use_splitkv_smallq(
+                param.max_seqlen_q, std::max(param.K, param.Kv))) {
           grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch<
               ScalarType,
               kHasMask,
@@ -46,7 +47,8 @@ void run_grouped_forward_mask_bias_dropout_dispatch(
           });
         }
       } else {
-        // Unreachable. Do not instantiate split-kv pipelines with head dimension > 256
+        // Unreachable. Do not instantiate split-kv pipelines with head
+        // dimension > 256
       }
     } else {
       if (get_fmha_fwd_mtile(param.num_batches, param.Hq, param.max_seqlen_q) ==

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_dispatch.h
@@ -47,7 +47,7 @@ struct grouped_forward_mask_bias_dropout_dispatch {
     using FmhaFwdShape_ = FmhaFwdShape<MaxK>;
 
     constexpr ck_tile::index_t occupancy = (MaxK == 64) ? 3
-        : (MaxK == 256)                                 ? 1
+        : (MaxK >= 256)                                 ? 1
                                                         : 2;
 
     constexpr auto kBiasEnum = kHasBias

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
@@ -23,6 +23,7 @@ void run_grouped_infer_mask_bias_dropout_dispatch(
   if constexpr (!kHasDropout) {
 #ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
+      if constexpr (MaxK <= 256) {
       FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
         grouped_infer_splitkv_mask_bias_dropout_dispatch<
             ScalarType,
@@ -31,6 +32,7 @@ void run_grouped_infer_mask_bias_dropout_dispatch(
             MaxK,
             MaxSeqlenQ>::Run(param, stream);
       });
+      }
     } else
 #endif
       grouped_infer_mask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
@@ -24,14 +24,21 @@ void run_grouped_infer_mask_bias_dropout_dispatch(
 #ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
       if constexpr (MaxK <= 256) {
-      FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
-        grouped_infer_splitkv_mask_bias_dropout_dispatch<
-            ScalarType,
-            kHasMask,
-            kHasBias,
-            MaxK,
-            MaxSeqlenQ>::Run(param, stream);
-      });
+        FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
+          grouped_infer_splitkv_mask_bias_dropout_dispatch<
+              ScalarType,
+              kHasMask,
+              kHasBias,
+              MaxK,
+              MaxSeqlenQ>::Run(param, stream);
+        });
+      } else {
+        grouped_infer_mask_bias_dropout_dispatch<
+          ScalarType,
+          kHasMask,
+          kHasBias,
+          kHasDropout,
+          MaxK>::Run(param, stream);
       }
     } else
 #endif

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
@@ -34,11 +34,11 @@ void run_grouped_infer_mask_bias_dropout_dispatch(
         });
       } else {
         grouped_infer_mask_bias_dropout_dispatch<
-          ScalarType,
-          kHasMask,
-          kHasBias,
-          kHasDropout,
-          MaxK>::Run(param, stream);
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK>::Run(param, stream);
       }
     } else
 #endif

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
@@ -23,33 +23,30 @@ template <
 void run_grouped_infer_mask_bias_dropout_dispatch(
     GroupedForwardParams& param,
     hipStream_t stream) {
-  if constexpr (MaxK > 256) {
-    grouped_infer_mask_bias_dropout_dispatch<
-        ScalarType,
-        kHasMask,
-        kHasBias,
-        kHasDropout,
-        MaxK,
-        128>::Run(param, stream);
-  } else
-  // currently split-kv implementation does not support dropout
+  // currently split-kv implementation does not support: 
+  // (*) dropout
+  // (*) head dimension > 256  
   if constexpr (!kHasDropout) {
-    if (param.use_split_kv) {
-      if (use_splitkv_smallq(param.max_seqlen_q, std::max(param.K, param.Kv))) {
-        grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch<
-            ScalarType,
-            kHasMask,
-            kHasBias,
-            MaxK>::Run(param, stream);
-      } else {
-        FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
-          grouped_infer_splitkv_mask_bias_dropout_dispatch<
+    if (param.use_split_kv && MaxK <= 256) {
+      if constexpr (MaxK <= 256) {
+        if (use_splitkv_smallq(param.max_seqlen_q, std::max(param.K, param.Kv))) {
+          grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch<
               ScalarType,
               kHasMask,
               kHasBias,
-              MaxK,
-              MaxSeqlenQ>::Run(param, stream);
-        });
+              MaxK>::Run(param, stream);
+        } else {
+          FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
+            grouped_infer_splitkv_mask_bias_dropout_dispatch<
+                ScalarType,
+                kHasMask,
+                kHasBias,
+                MaxK,
+                MaxSeqlenQ>::Run(param, stream);
+          });
+        }
+      } else {
+        // Unreachable. Do not instantiate split-kv pipelines with head dimension > 256
       }
     } else {
       if (get_fmha_fwd_mtile(param.num_batches, param.Hq, param.max_seqlen_q) ==

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
@@ -23,13 +23,14 @@ template <
 void run_grouped_infer_mask_bias_dropout_dispatch(
     GroupedForwardParams& param,
     hipStream_t stream) {
-  // currently split-kv implementation does not support: 
+  // currently split-kv implementation does not support:
   // (*) dropout
-  // (*) head dimension > 256  
+  // (*) head dimension > 256
   if constexpr (!kHasDropout) {
     if (param.use_split_kv && MaxK <= 256) {
       if constexpr (MaxK <= 256) {
-        if (use_splitkv_smallq(param.max_seqlen_q, std::max(param.K, param.Kv))) {
+        if (use_splitkv_smallq(
+                param.max_seqlen_q, std::max(param.K, param.Kv))) {
           grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch<
               ScalarType,
               kHasMask,
@@ -46,7 +47,8 @@ void run_grouped_infer_mask_bias_dropout_dispatch(
           });
         }
       } else {
-        // Unreachable. Do not instantiate split-kv pipelines with head dimension > 256
+        // Unreachable. Do not instantiate split-kv pipelines with head
+        // dimension > 256
       }
     } else {
       if (get_fmha_fwd_mtile(param.num_batches, param.Hq, param.max_seqlen_q) ==

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
@@ -80,8 +80,10 @@ struct grouped_infer_mask_bias_dropout_dispatch {
             using FmhaPipelineProblem =
                 FmhaPipelineProblemTemp<FmhaTraits, FmhaMask>;
 
-            using FmhaPipeline = std::conditional_t<MaxK <= 256, ck_tile::BlockFmhaPipelineQRKSVS<FmhaPipelineProblem>, ck_tile::BlockFmhaPipelineQSKSVS<FmhaPipelineProblem>>;
-
+            using FmhaPipeline = std::conditional_t<
+                MaxK <= 256,
+                ck_tile::BlockFmhaPipelineQRKSVS<FmhaPipelineProblem>,
+                ck_tile::BlockFmhaPipelineQSKSVS<FmhaPipelineProblem>>;
 
             using FmhaEpilogue =
                 ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -126,8 +128,10 @@ struct grouped_infer_mask_bias_dropout_dispatch {
 
       using FmhaPipelineProblem = FmhaPipelineProblemTemp<FmhaTraits, FmhaMask>;
 
-      using FmhaPipeline = std::conditional_t<MaxK <= 256, ck_tile::BlockFmhaPipelineQRKSVSAsync<FmhaPipelineProblem>, ck_tile::BlockFmhaPipelineQSKSVS<FmhaPipelineProblem>>;
-
+      using FmhaPipeline = std::conditional_t<
+          MaxK <= 256,
+          ck_tile::BlockFmhaPipelineQRKSVSAsync<FmhaPipelineProblem>,
+          ck_tile::BlockFmhaPipelineQSKSVS<FmhaPipelineProblem>>;
 
       using FmhaEpilogue =
           ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
@@ -47,7 +47,7 @@ struct grouped_infer_mask_bias_dropout_dispatch {
 
     using FmhaShape = FmhaFwdShape<MaxK>;
     constexpr ck_tile::index_t occupancy =
-        (MaxK == 64) ? 3 : ((MaxK == 256) ? 1 : 2);
+        (MaxK == 64) ? 3 : ((MaxK >= 256) ? 1 : 2);
 
     constexpr auto kBiasEnum = kHasBias
         ? ck_tile::BlockAttentionBiasEnum::ELEMENTWISE_BIAS

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
@@ -80,8 +80,8 @@ struct grouped_infer_mask_bias_dropout_dispatch {
             using FmhaPipelineProblem =
                 FmhaPipelineProblemTemp<FmhaTraits, FmhaMask>;
 
-            using FmhaPipeline =
-                ck_tile::BlockFmhaPipelineQRKSVS<FmhaPipelineProblem>;
+            using FmhaPipeline = std::conditional_t<MaxK <= 256, ck_tile::BlockFmhaPipelineQRKSVS<FmhaPipelineProblem>, ck_tile::BlockFmhaPipelineQSKSVS<FmhaPipelineProblem>>;
+
 
             using FmhaEpilogue =
                 ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -126,8 +126,8 @@ struct grouped_infer_mask_bias_dropout_dispatch {
 
       using FmhaPipelineProblem = FmhaPipelineProblemTemp<FmhaTraits, FmhaMask>;
 
-      using FmhaPipeline =
-          ck_tile::BlockFmhaPipelineQRKSVSAsync<FmhaPipelineProblem>;
+      using FmhaPipeline = std::conditional_t<MaxK <= 256, ck_tile::BlockFmhaPipelineQRKSVSAsync<FmhaPipelineProblem>, ck_tile::BlockFmhaPipelineQSKSVS<FmhaPipelineProblem>>;
+
 
       using FmhaEpilogue =
           ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
@@ -9,52 +9,6 @@
 #include <ck_tile/core.hpp>
 #include <stdexcept>
 
-#ifndef FMHA_SUPPORT_MAX_HEADDIM_128
-#define FMHA_SUPPORT_MAX_HEADDIM_128 0
-#endif
-
-#if FMHA_SUPPORT_MAX_HEADDIM_128
-
-#define FMHA_FWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
-  [&] {                                                                \
-    if (HEAD_DIM1 <= 32 && HEAD_DIM2 <= 32) {                          \
-      constexpr ck_tile::index_t CONST_NAME = 32;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 64 && HEAD_DIM2 <= 64) {                   \
-      constexpr ck_tile::index_t CONST_NAME = 64;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 96 && HEAD_DIM2 <= 96) {                   \
-      constexpr ck_tile::index_t CONST_NAME = 96;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 128 && HEAD_DIM2 <= 128) {                 \
-      constexpr ck_tile::index_t CONST_NAME = 128;                     \
-      __VA_ARGS__();                                                   \
-    } else {                                                           \
-      throw std::runtime_error("Head-dim sizes not supported!");       \
-    }                                                                  \
-  }()
-
-#define FMHA_BWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
-  [&] {                                                                \
-    if (HEAD_DIM1 <= 32 && HEAD_DIM2 <= 32) {                          \
-      constexpr ck_tile::index_t CONST_NAME = 32;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 64 && HEAD_DIM2 <= 64) {                   \
-      constexpr ck_tile::index_t CONST_NAME = 64;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 96 && HEAD_DIM2 <= 96) {                   \
-      constexpr ck_tile::index_t CONST_NAME = 96;                      \
-      __VA_ARGS__();                                                   \
-    } else if (HEAD_DIM1 <= 128 && HEAD_DIM2 <= 128) {                 \
-      constexpr ck_tile::index_t CONST_NAME = 128;                     \
-      __VA_ARGS__();                                                   \
-    } else {                                                           \
-      throw std::runtime_error("Head-dim sizes not supported!");       \
-    }                                                                  \
-  }()
-
-#else
-
 #define FMHA_FWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
   [&] {                                                                \
     if (HEAD_DIM1 <= 32 && HEAD_DIM2 <= 32) {                          \
@@ -101,5 +55,3 @@
       throw std::runtime_error("Head-dim sizes not supported!");       \
     }                                                                  \
   }()
-
-#endif

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
@@ -9,6 +9,36 @@
 #include <ck_tile/core.hpp>
 #include <stdexcept>
 
+#ifndef FMHA_LIMIT_MAX_HEADDIM_TO_256
+#define FMHA_LIMIT_MAX_HEADDIM_TO_256 1
+#endif
+
+#if FMHA_LIMIT_MAX_HEADDIM_TO_256
+
+#define FMHA_FWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
+  [&] {                                                                \
+    if (HEAD_DIM1 <= 32 && HEAD_DIM2 <= 32) {                          \
+      constexpr ck_tile::index_t CONST_NAME = 32;                      \
+      __VA_ARGS__();                                                   \
+    } else if (HEAD_DIM1 <= 64 && HEAD_DIM2 <= 64) {                   \
+      constexpr ck_tile::index_t CONST_NAME = 64;                      \
+      __VA_ARGS__();                                                   \
+    } else if (HEAD_DIM1 <= 96 && HEAD_DIM2 <= 96) {                   \
+      constexpr ck_tile::index_t CONST_NAME = 96;                      \
+      __VA_ARGS__();                                                   \
+    } else if (HEAD_DIM1 <= 128 && HEAD_DIM2 <= 128) {                 \
+      constexpr ck_tile::index_t CONST_NAME = 128;                     \
+      __VA_ARGS__();                                                   \
+    } else if (HEAD_DIM1 <= 256 && HEAD_DIM2 <= 256) {                 \
+      constexpr ck_tile::index_t CONST_NAME = 256;                     \
+      __VA_ARGS__();                                                   \
+    } else {                                                           \
+      throw std::runtime_error("Head-dim sizes not supported!");       \
+    }                                                                  \
+  }()
+
+#else
+
 #define FMHA_FWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
   [&] {                                                                \
     if (HEAD_DIM1 <= 32 && HEAD_DIM2 <= 32) {                          \
@@ -33,6 +63,8 @@
       throw std::runtime_error("Head-dim sizes not supported!");       \
     }                                                                  \
   }()
+
+#endif
 
 #define FMHA_BWD_HEADDIM_SWITCH(HEAD_DIM1, HEAD_DIM2, CONST_NAME, ...) \
   [&] {                                                                \

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_headdim_switch.h
@@ -72,6 +72,9 @@
     } else if (HEAD_DIM1 <= 256 && HEAD_DIM2 <= 256) {                 \
       constexpr ck_tile::index_t CONST_NAME = 256;                     \
       __VA_ARGS__();                                                   \
+    } else if (HEAD_DIM1 <= 512 && HEAD_DIM2 <= 512) {                 \
+      constexpr ck_tile::index_t CONST_NAME = 512;                     \
+      __VA_ARGS__();                                                   \
     } else {                                                           \
       throw std::runtime_error("Head-dim sizes not supported!");       \
     }                                                                  \

--- a/xformers/csrc/attention/hip_fmha/generate_instances.py
+++ b/xformers/csrc/attention/hip_fmha/generate_instances.py
@@ -21,7 +21,9 @@ FMHA_COPYRIGHT_HEADER = """
  * See the generator script
  * `{file}`
  */
-""".format(file=os.path.relpath(os.path.realpath(__file__), start=Path(__file__).parents[4]))
+""".format(
+    file=os.path.relpath(os.path.realpath(__file__), start=Path(__file__).parents[4])
+)
 
 FMHA_INFER_INSTANCE_TEMPLATE_INC = """
 #include <ck_tile/core/numeric/{dtype_file}.hpp>
@@ -105,9 +107,7 @@ BOOL_MAP_DROPOUT = {
     False: "no_dropout",
 }
 
-INT_MAP_MAX_K = {
-    hd: f"maxk_{hd}" for hd in [32, 64, 96, 128, 256, 512]
-}
+INT_MAP_MAX_K = {hd: f"maxk_{hd}" for hd in [32, 64, 96, 128, 256, 512]}
 
 TYPE_CTYPE_MAP = {
     "fp16": "ck_tile::fp16_t",

--- a/xformers/csrc/attention/hip_fmha/generate_instances.py
+++ b/xformers/csrc/attention/hip_fmha/generate_instances.py
@@ -354,15 +354,15 @@ def create_backward_instances_ref(instance_dir: Path, headdims: List) -> None:
 
 
 if __name__ == "__main__":
-    disable_hd256 = False
+    disable_hd512 = False
 
     for arg in sys.argv:
-        if arg == "--ignore-hd256":
-            disable_hd256 = True
+        if arg == "--ignore-hd512":
+            disable_hd512 = True
 
-    if disable_hd256:
-        headdims_fwd = [32, 64, 96, 128]
-        headdims_bwd = [32, 64, 96, 128]
+    if disable_hd512:
+        headdims_fwd = [32, 64, 96, 128, 256]
+        headdims_bwd = [32, 64, 96, 128, 256]
     else:
         headdims_fwd = [32, 64, 96, 128, 256, 512]
         headdims_bwd = [32, 64, 96, 128, 256]

--- a/xformers/csrc/attention/hip_fmha/generate_instances.py
+++ b/xformers/csrc/attention/hip_fmha/generate_instances.py
@@ -18,8 +18,9 @@ FMHA_COPYRIGHT_HEADER = """
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `{file}`
  */
-"""
+""".format(file=__file__)
 
 FMHA_INFER_INSTANCE_TEMPLATE_INC = """
 #include <ck_tile/core/numeric/{dtype_file}.hpp>
@@ -104,11 +105,7 @@ BOOL_MAP_DROPOUT = {
 }
 
 INT_MAP_MAX_K = {
-    32: "maxk_32",
-    64: "maxk_64",
-    96: "maxk_96",
-    128: "maxk_128",
-    256: "maxk_256",
+    hd: f"maxk_{hd}" for hd in [32, 64, 96, 128, 256, 512]
 }
 
 TYPE_CTYPE_MAP = {
@@ -372,7 +369,7 @@ if __name__ == "__main__":
         headdims_fwd = [32, 64, 96, 128]
         headdims_bwd = [32, 64, 96, 128]
     else:
-        headdims_fwd = [32, 64, 96, 128, 256]
+        headdims_fwd = [32, 64, 96, 128, 256, 512]
         headdims_bwd = [32, 64, 96, 128, 256]
 
     this_dir = os.path.dirname(__file__)

--- a/xformers/csrc/attention/hip_fmha/generate_instances.py
+++ b/xformers/csrc/attention/hip_fmha/generate_instances.py
@@ -18,7 +18,8 @@ FMHA_COPYRIGHT_HEADER = """
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `{file}`
+ * See the generator script
+ * `{file}`
  */
 """.format(file=os.path.relpath(os.path.realpath(__file__), start=Path(__file__).parents[4]))
 

--- a/xformers/csrc/attention/hip_fmha/generate_instances.py
+++ b/xformers/csrc/attention/hip_fmha/generate_instances.py
@@ -20,7 +20,7 @@ FMHA_COPYRIGHT_HEADER = """
  * The file is automatically generated, don't modify!
  * See the generator script `{file}`
  */
-""".format(file=__file__)
+""".format(file=os.path.relpath(os.path.realpath(__file__), start=Path(__file__).parents[4]))
 
 FMHA_INFER_INSTANCE_TEMPLATE_INC = """
 #include <ck_tile/core/numeric/{dtype_file}.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>
@@ -290,3 +291,59 @@ extern template void run_batched_forward_mask_bias_dropout_dispatch<
     false,
     false,
     256>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>
@@ -290,3 +291,59 @@ extern template void run_batched_forward_mask_bias_dropout_dispatch<
     false,
     false,
     256>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_forward.h"
+
+template void run_batched_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>
@@ -290,3 +291,59 @@ extern template void run_batched_infer_mask_bias_dropout_dispatch<
     false,
     false,
     256>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>
@@ -290,3 +291,59 @@ extern template void run_batched_infer_mask_bias_dropout_dispatch<
     false,
     false,
     256>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);
+
+extern template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_batched_infer.h"
+
+template void run_batched_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    512>(BatchedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_bf16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_has_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_has_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_has_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_backward_fp16_no_mask_no_bias_no_biasgrad_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>
@@ -290,3 +291,59 @@ extern template void run_grouped_forward_mask_bias_dropout_dispatch<
     false,
     false,
     256>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>
@@ -290,3 +291,59 @@ extern template void run_grouped_forward_mask_bias_dropout_dispatch<
     false,
     false,
     256>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_forward.h"
+
+template void run_grouped_forward_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_forward_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>
@@ -290,3 +291,59 @@ extern template void run_grouped_infer_mask_bias_dropout_dispatch<
     false,
     false,
     256>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    true,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/bfloat16.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::bf16_t,
+    false,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_bf16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/bfloat16.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_has_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_instances_ref.h
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_instances_ref.h
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_instances_ref.h
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_instances_ref.h
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>
@@ -290,3 +291,59 @@ extern template void run_grouped_infer_mask_bias_dropout_dispatch<
     false,
     false,
     256>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    true,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);
+
+extern template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    true,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_has_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    true,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_has_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_128.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_256.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_32.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_512.cpp
@@ -1,0 +1,20 @@
+
+/*
+  Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ */
+
+#include <ck_tile/core/numeric/half.hpp>
+#include "ck_tiled_fmha_grouped_infer.h"
+
+template void run_grouped_infer_mask_bias_dropout_dispatch<
+    ck_tile::fp16_t,
+    false,
+    false,
+    false,
+    512>(GroupedForwardParams& param, hipStream_t stream);

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_64.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
+ * See the generator script `/home/mpodkory/xformers/xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
+++ b/xformers/csrc/attention/hip_fmha/instances/fmha_grouped_infer_fp16_no_mask_no_bias_no_dropout_maxk_96.cpp
@@ -6,7 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  * The file is automatically generated, don't modify!
- * See the generator script `xformers/csrc/attention/hip_fmha/generate_instances.py`
+ * See the generator script
+ * `xformers/csrc/attention/hip_fmha/generate_instances.py`
  */
 
 #include <ck_tile/core/numeric/half.hpp>

--- a/xformers/ops/fmha/ck.py
+++ b/xformers/ops/fmha/ck.py
@@ -151,7 +151,7 @@ class FwOp(AttentionFwOpBase):
     OPERATOR = get_operator("xformers", "efficient_attention_forward_ck")
     SUPPORTED_DEVICES: Set[str] = {"cuda"}
     SUPPORTED_DTYPES: Set[torch.dtype] = {torch.half, torch.bfloat16}
-    SUPPORTED_MAX_K = 256
+    SUPPORTED_MAX_K = 512
 
     SUPPORTED_ATTN_BIAS_TYPES: Iterable[Any] = (
         type(None),

--- a/xformers/ops/fmha/ck.py
+++ b/xformers/ops/fmha/ck.py
@@ -203,6 +203,7 @@ class FwOp(AttentionFwOpBase):
         96,
         128,  # 64x128 kernel
         256,  # 64x128 with accumulation in gmem
+        512,
     ]
 
     @classmethod


### PR DESCRIPTION
## Testing
```
pytest -rpfs /xformers/tests/test_mem_eff_attention.py -k "512 and ckF"
```

```
=== 11 failed, 77 passed, 210 skipped, 11392 deselected, 144 warnings in 17.83s ===
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-PagedBlockDiagonalCausalWithOffsetPaddedKeysMask-1-32-32-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularFromBottomRightLocalAttentionMask-1-32-32-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularFromBottomRightLocalAttentionMask-1-32-32-1-512-512-True-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalCausalLocalAttentionMask-1-32-64-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalMask-1-32-64-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalPaddedKeysMask-1-32-256-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalCausalWithOffsetGappyKeysMask-1-32-256-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalCausalFromBottomRightMask-1-32-1026-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularFromBottomRightMask-1-32-1026-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalCausalWithOffsetPaddedKeysMask-1-32-256-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalCausalLocalAttentionMask-1-32-256-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalMask-1-256-64-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-PagedBlockDiagonalPaddedKeysMask-1-64-256-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-LowerTriangularMaskWithTensorBias-1-256-256-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-LowerTriangularMaskWithTensorBias-1-256-256-1-512-512-True-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalCausalFromBottomRightMask-1-256-258-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalGappyKeysMask-1-256-1024-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-PagedBlockDiagonalCausalWithOffsetPaddedKeysMask-1-256-1024-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-LowerTriangularMaskWithTensorBias-1-256-128-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-Tensor-1-256-128-1-512-512-False-BMK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-Tensor-1-256-128-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-PagedBlockDiagonalPaddedKeysMask-1-16-1024-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalGappyKeysMask-1-16-1024-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalCausalLocalAttentionMask-1-1024-16-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalCausalWithOffsetPaddedKeysMask-1-16-1024-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-PagedBlockDiagonalCausalWithOffsetPaddedKeysMask-1-128-256-3-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularFromBottomRightLocalAttentionMask-1-128-256-3-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalMask-1-256-128-5-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularFromBottomRightLocalAttentionMask-1-256-128-5-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalCausalLocalAttentionMask-1-256-128-12-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalMask-1-256-128-12-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalCausalWithOffsetPaddedKeysMask-12-32-32-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalCausalWithOffsetPaddedKeysMask-12-32-32-1-512-512-True-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularMaskWithTensorBias-12-32-32-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularMaskWithTensorBias-12-32-32-1-512-512-True-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalCausalFromBottomRightMask-12-32-66-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalGappyKeysMask-12-32-66-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalPaddedKeysMask-12-32-256-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalMask-12-32-256-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-LowerTriangularFromBottomRightMask-12-32-1024-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularMask-12-32-1024-1-512-512-False-BMK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularMask-12-32-1024-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalCausalLocalAttentionFromBottomRightMask-12-32-258-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalCausalWithOffsetGappyKeysMask-12-32-258-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalGappyKeysMask-12-256-64-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularMaskWithTensorBias-12-256-64-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-Tensor-12-256-256-1-512-512-False-BMK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-Tensor-12-256-256-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-Tensor-12-256-256-1-512-512-True-BMK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-Tensor-12-256-256-1-512-512-True-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-LowerTriangularMaskWithTensorBias-12-256-1024-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularMask-12-256-1024-1-512-512-False-BMK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularMask-12-256-1024-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-LowerTriangularMaskWithTensorBias-12-256-128-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalCausalLocalAttentionMask-12-16-1024-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularMask-12-1024-16-1-512-512-False-BMK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-LowerTriangularMask-12-1024-16-1-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-BlockDiagonalPaddedKeysMask-12-128-256-5-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-BlockDiagonalCausalWithOffsetGappyKeysMask-12-128-256-12-512-512-False-BMHK]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-NoneType-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-Tensor-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-LowerTriangularMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-LowerTriangularFromBottomRightMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-LowerTriangularFromBottomRightLocalAttentionMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-LowerTriangularMaskWithTensorBias-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-BlockDiagonalMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-BlockDiagonalCausalMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-BlockDiagonalCausalWithOffsetGappyKeysMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-BlockDiagonalCausalWithOffsetPaddedKeysMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-BlockDiagonalGappyKeysMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-BlockDiagonalPaddedKeysMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-BlockDiagonalCausalFromBottomRightMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-BlockDiagonalCausalLocalAttentionMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-BlockDiagonalCausalLocalAttentionFromBottomRightMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-PagedBlockDiagonalPaddedKeysMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-PagedBlockDiagonalCausalWithOffsetPaddedKeysMask-512]
PASSED tests/test_mem_eff_attention.py::test_forward_gqa[ckF-PagedBlockDiagonalGappyKeysMask-512]
FAILED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-NoneType-300-256-256-1-512-512-False-BMK] - AssertionError: failed: out=-10.625 and ref=9.20634937286377 (diff=19.619220733642578 > 0) at (60, 179, 399) of shape (300, 256, 512) / atol=0.028, rtol=0.02/ total fai...
FAILED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-NoneType-300-256-256-1-512-512-False-BMHK] - AssertionError: failed: out=-10.625 and ref=9.20634937286377 (diff=19.619220733642578 > 0) at (60, 179, 0, 399) of shape (300, 256, 1, 512) / atol=0.028, rtol=0.02/ tot...
FAILED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-NoneType-300-256-256-1-512-512-True-BMK] - AssertionError: failed: out=-10.625 and ref=9.20634937286377 (diff=19.619220733642578 > 0) at (60, 179, 399) of shape (300, 256, 512) / atol=0.028, rtol=0.02/ total fai...
FAILED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-NoneType-300-256-256-1-512-512-True-BMHK] - AssertionError: failed: out=-10.625 and ref=9.20634937286377 (diff=19.619220733642578 > 0) at (60, 179, 0, 399) of shape (300, 256, 1, 512) / atol=0.028, rtol=0.02/ tot...
FAILED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-PagedBlockDiagonalCausalWithOffsetPaddedKeysMask-12-128-256-1-512-512-False-BMHK] - AssertionError: failed: out=12.515625 and ref=-9.329191207885742 (diff=21.810827255249023 > 0) at (0, 1481, 0, 380) of shape (1, 1536, 1, 512) / atol=0.006, rtol=0.003/...
FAILED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-PagedBlockDiagonalCausalWithOffsetPaddedKeysMask-12-16-1024-1-512-512-False-BMHK] - AssertionError: failed: out=-6.5 and ref=10.984909057617188 (diff=17.237211227416992 > 0) at (0, 95, 0, 333) of shape (1, 192, 1, 512) / atol=0.028, rtol=0.02/ total fa...
FAILED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-LowerTriangularFromBottomRightMask-12-1024-16-1-512-512-False-BMHK] - AssertionError: failed: out=9.4375 and ref=-5.229033470153809 (diff=14.533952713012695 > 0) at (8, 978, 0, 386) of shape (12, 1024, 1, 512) / atol=0.028, rtol=0.02/ tot...
FAILED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-PagedBlockDiagonalGappyKeysMask-12-256-128-3-512-512-False-BMHK] - AssertionError: failed: out=11.625 and ref=-9.425588607788086 (diff=20.834077835083008 > 0) at (0, 1622, 2, 300) of shape (1, 3072, 3, 512) / atol=0.028, rtol=0.02/ tot...
FAILED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-PagedBlockDiagonalCausalWithOffsetPaddedKeysMask-12-128-256-3-512-512-False-BMHK] - AssertionError: failed: out=-7.328125 and ref=13.373323440551758 (diff=20.65532875061035 > 0) at (0, 1078, 1, 429) of shape (1, 1536, 3, 512) / atol=0.006, rtol=0.003/ ...
FAILED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.float16-PagedBlockDiagonalCausalWithOffsetPaddedKeysMask-12-128-256-5-512-512-False-BMHK] - AssertionError: failed: out=-9.3125 and ref=10.826526641845703 (diff=20.10054588317871 > 0) at (0, 52, 4, 155) of shape (1, 1536, 5, 512) / atol=0.006, rtol=0.003/ tota...
FAILED tests/test_mem_eff_attention.py::test_forward[ckF-cuda-torch.bfloat16-PagedBlockDiagonalCausalWithOffsetPaddedKeysMask-12-128-256-12-512-512-False-BMHK] - AssertionError: failed: out=-11.8125 and ref=11.496965408325195 (diff=23.05152702331543 > 0) at (0, 470, 7, 20) of shape (1, 1536, 12, 512) / atol=0.028, rtol=0.02/ tot...
```