### PR TITLE
Add support for using splitkv nwarps s-shuffling pipeline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "third_party/composable_kernel_tiled"]
 	path = third_party/composable_kernel_tiled
 	url = https://github.com/ROCm/composable_kernel.git
-	branch = feature/add-small-warp-gemm
+	branch = develop

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "third_party/composable_kernel_tiled"]
 	path = third_party/composable_kernel_tiled
 	url = https://github.com/ROCm/composable_kernel.git
-	branch = feature/add-small-warp-gemm-zqf 
+	branch = feature/add-small-warp-gemm

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "third_party/composable_kernel_tiled"]
 	path = third_party/composable_kernel_tiled
 	url = https://github.com/ROCm/composable_kernel.git
-	branch = develop 
+	branch = feature/add-small-warp-gemm-zqf 

--- a/setup.py
+++ b/setup.py
@@ -457,10 +457,6 @@ def get_extensions():
         if use_rtn_bf16_convert == "1":
             cc_flag += ["-DCK_TILE_FLOAT_TO_BFLOAT16_DEFAULT=3"]
 
-        disable_fmha_fwd_splitkv = os.getenv("DISABLE_HIP_FMHA_FWD_SPLITKV", "0")
-        if disable_fmha_fwd_splitkv == "1":
-            cc_flag += ["-DFMHA_FWD_SPLITKV_NOT_USED"]
-
         arch_list = os.getenv("HIP_ARCHITECTURES", "native").split()
 
         extra_compile_args = {

--- a/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
@@ -244,7 +244,7 @@ efficient_attention_forward_ck(
     int num_kv_splits;
 
     std::tie(use_split_kv, num_kv_splits) =
-        get_num_kv_splits_heuristic(p.B, p.Hq, p.M, std::max(p.K, p.Kv), 32);
+        get_num_kv_splits_heuristic(p.B, p.Hq, p.M, std::max(p.K, p.Kv), 8);
 
     // 1) fmha fwd split-kv kernel does not support dropout
     p.use_split_kv = (!use_dropout && use_split_kv) ? true : false;
@@ -393,7 +393,7 @@ efficient_attention_forward_ck(
 
     // added for support split_kv
     std::tie(use_split_kv, num_kv_splits) = get_num_kv_splits_heuristic(
-        p.num_batches, p.Hq, p.max_seqlen_q, std::max(p.K, p.Kv), 32);
+        p.num_batches, p.Hq, p.max_seqlen_q, std::max(p.K, p.Kv), 8);
 
     // 1) fmha fwd split-kv kernel does not support dropout
     // 2) Paged-KVcache is only available from the split-kv kernel at present

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
@@ -25,7 +25,6 @@ void run_batched_forward_mask_bias_dropout_dispatch(
     hipStream_t stream) {
   // currently split-kv implementation does not support dropout
   if constexpr (!kHasDropout) {
-#ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
       if (use_splitkv_smallq(param.M, std::max(param.K, param.Kv))) {
         batched_forward_splitkv_smallq_mask_bias_dropout_dispatch<
@@ -43,9 +42,7 @@ void run_batched_forward_mask_bias_dropout_dispatch(
               MaxSeqlenQ>::Run(param, stream);
         });
       }
-    } else
-#endif
-    {
+    } else {
       if (get_fmha_fwd_mtile(param.B, param.Hq, param.M) == 128)
         batched_forward_mask_bias_dropout_dispatch<
             ScalarType,

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_dispatch.h
@@ -21,7 +21,8 @@ template <
     bool kHasMask,
     bool kHasBias,
     bool kHasDropout,
-    ck_tile::index_t MaxK>
+    ck_tile::index_t MaxK,
+    ck_tile::index_t MTile>
 struct batched_forward_mask_bias_dropout_dispatch {
   template <typename FmhaTraits, typename FmhaMask>
   using FmhaPipelineProblemTemp = ck_tile::BlockFmhaPipelineProblem<
@@ -36,7 +37,7 @@ struct batched_forward_mask_bias_dropout_dispatch {
       typename FmhaFwdTypeConfig<ScalarType>::PDataType,
       typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
       typename FmhaFwdTypeConfig<ScalarType>::ODataType,
-      FmhaFwdShape<MaxK>,
+      typename FmhaFwdShape<MaxK, MTile>::Type,
       false, // kIsGroupMode
       FmhaMask,
       FmhaTraits>;
@@ -44,7 +45,7 @@ struct batched_forward_mask_bias_dropout_dispatch {
   static void Run(BatchedForwardParams& param, hipStream_t stream) {
     using FmhaMask = ck_tile::SimplifiedGenericAttentionMask<kHasMask>;
 
-    using FmhaFwdShape_ = FmhaFwdShape<MaxK>;
+    using FmhaFwdShape_ = typename FmhaFwdShape<MaxK, MTile>::Type;
     using FmhaFwdTilePartitioner_ =
         ck_tile::FmhaFwdTilePartitioner<FmhaFwdShape_>;
     constexpr ck_tile::index_t occupancy =

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_dispatch.h
@@ -45,19 +45,15 @@ struct batched_forward_splitkv_mask_bias_dropout_dispatch {
           FmhaMask,
           FmhaFwdSplitKVTraits>;
 
-  template <
-      ck_tile::index_t kM0,
-      ck_tile::index_t kN1,
-      typename FmhaSplitKVCombineTraits>
+  template <ck_tile::index_t kN1, typename FmhaSplitKVCombineTraits>
   using FmhaSplitKVCombinePipelineProblemTemp =
       ck_tile::BlockFmhaSplitKVCombinePipelineProblem<
           typename FmhaFwdTypeConfig<ScalarType>::LSEDataType,
           typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
           typename FmhaFwdTypeConfig<ScalarType>::ODataType,
           MaxK, // headdim_v
-          kM0,
-          kN1,
           false, // kIsGroupMode
+          kN1,
           FmhaSplitKVCombineTraits>;
 
   static void Run(BatchedForwardParams& param, hipStream_t stream) {
@@ -164,8 +160,11 @@ struct batched_forward_splitkv_mask_bias_dropout_dispatch {
       using FmhaTileShape =
           typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type;
 
-      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0 / 2;
-      constexpr ck_tile::index_t kN1 = FmhaTileShape::kN1 / 2;
+      constexpr ck_tile::index_t kN1 = 32;
+      constexpr ck_tile::index_t kM0 =
+          ck_tile::BlockFmhaSplitKVCombinePipelineTileSizes<
+              typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+              kN1>::kM0;
 
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVCombineTilePartitioner<kM0, kN1>;
@@ -187,10 +186,7 @@ struct batched_forward_splitkv_mask_bias_dropout_dispatch {
                       -1>;
 
                   using FmhaPipelineProblem =
-                      FmhaSplitKVCombinePipelineProblemTemp<
-                          kM0,
-                          kN1,
-                          FmhaTraits>;
+                      FmhaSplitKVCombinePipelineProblemTemp<kN1, FmhaTraits>;
 
                   using FmhaPipeline =
                       ck_tile::BlockFmhaFwdSplitKVCombinePipeline<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_dispatch.h
@@ -13,7 +13,7 @@
 #include <ck_tile/ops/fmha.hpp>
 
 #include "ck_tiled_bool_switch.h"
-#include "ck_tiled_fmha_fwd_setting.h"
+#include "ck_tiled_fmha_fwd_splitkv_setting.h"
 #include "ck_tiled_fmha_num_kv_split_switch.h"
 #include "ck_tiled_fmha_params.h"
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
@@ -111,7 +111,7 @@ struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
                   ODataType>;
 
               using FmhaPipeline =
-                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                  ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
                       FmhaPipelineProblem>;
 
               using FmhaEpilogue =
@@ -136,7 +136,7 @@ struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
                   ODataType>;
 
               using FmhaPipeline =
-                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                  ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
                       FmhaPipelineProblem>;
 
               using FmhaEpilogue =

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
@@ -44,19 +44,15 @@ struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
           FmhaMask,
           FmhaFwdSplitKVTraits>;
 
-  template <
-      ck_tile::index_t kM0,
-      ck_tile::index_t kN1,
-      typename FmhaSplitKVCombineTraits>
+  template <ck_tile::index_t kN1, typename FmhaSplitKVCombineTraits>
   using FmhaSplitKVCombinePipelineProblemTemp =
       ck_tile::BlockFmhaSplitKVCombinePipelineProblem<
           typename FmhaFwdTypeConfig<ScalarType>::LSEDataType,
           typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
           typename FmhaFwdTypeConfig<ScalarType>::ODataType,
           MaxK, // headdim_v
-          kM0,
-          kN1,
           false, // kIsGroupMode
+          kN1,
           FmhaSplitKVCombineTraits>;
 
   static void Run(BatchedForwardParams& param, hipStream_t stream) {
@@ -163,8 +159,11 @@ struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
     if (param.num_kv_splits > 1) {
       using FmhaTileShape = typename FmhaFwdSplitKVSmallQShape<MaxK>::Type;
 
-      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0;
-      constexpr ck_tile::index_t kN1 = FmhaTileShape::kN1 / 2;
+      constexpr ck_tile::index_t kN1 = 32;
+      constexpr ck_tile::index_t kM0 =
+          ck_tile::BlockFmhaSplitKVCombinePipelineTileSizes<
+              typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+              kN1>::kM0;
 
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVCombineTilePartitioner<kM0, kN1>;
@@ -186,10 +185,7 @@ struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
                       -1>;
 
                   using FmhaPipelineProblem =
-                      FmhaSplitKVCombinePipelineProblemTemp<
-                          kM0,
-                          kN1,
-                          FmhaTraits>;
+                      FmhaSplitKVCombinePipelineProblemTemp<kN1, FmhaTraits>;
 
                   using FmhaPipeline =
                       ck_tile::BlockFmhaFwdSplitKVCombinePipeline<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
@@ -218,7 +218,7 @@ struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
       BatchedForwardParams& param,
       hipStream_t stream) {
     const auto kargs = [&] {
-      if (param.num_kv_splits)
+      if (param.num_kv_splits > 1)
         return FmhaFwdSplitKVKernel::MakeKargs(
             param.q_ptr,
             param.k_ptr,

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
@@ -13,7 +13,7 @@
 #include <ck_tile/ops/fmha.hpp>
 
 #include "ck_tiled_bool_switch.h"
-#include "ck_tiled_fmha_fwd_splitkv_setting.h"
+#include "ck_tiled_fmha_fwd_splitkv_smallq_setting.h"
 #include "ck_tiled_fmha_num_kv_split_switch.h"
 #include "ck_tiled_fmha_params.h"
 
@@ -21,9 +21,8 @@ template <
     typename ScalarType,
     bool kHasMask,
     bool kHasBias,
-    ck_tile::index_t MaxK,
-    ck_tile::index_t MaxSeqlenQ>
-struct batched_infer_splitkv_mask_bias_dropout_dispatch {
+    ck_tile::index_t MaxK>
+struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
   template <
       typename FmhaFwdSplitKVTraits,
       typename FmhaMask,
@@ -40,7 +39,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
           typename FmhaFwdTypeConfig<ScalarType>::PDataType,
           typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
           ODataType,
-          typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type,
+          typename FmhaFwdSplitKVSmallQShape<MaxK>::Type,
           false, // kIsGroupMode
           FmhaMask,
           FmhaFwdSplitKVTraits>;
@@ -64,8 +63,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
     {
       using FmhaMask = ck_tile::SimplifiedGenericAttentionMask<kHasMask>;
 
-      using FmhaTileShape =
-          typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type;
+      using FmhaTileShape = typename FmhaFwdSplitKVSmallQShape<MaxK>::Type;
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVTilePartitioner<FmhaTileShape>;
       constexpr ck_tile::index_t occupancy = -1;
@@ -95,20 +93,20 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
           [&] {
             constexpr bool kPadSeqLenK = kHasUnevenSplits ? true : false;
 
-            if (param.num_kv_splits > 1) {
-              using FmhaTraits = ck_tile::TileFmhaFwdSplitKVTraits<
-                  kPadSeqLenQ,
-                  kPadSeqLenK,
-                  kPadHeadDim, // kPadHeadDimQ,
-                  kPadHeadDim, // kPadHeadDimV,
-                  kBiasEnum,
-                  false, // kHasBiasGrad place-holder
-                  true, // kStoreLSE
-                  false, // kDoFp8StaticQuant place-holder
-                  false, // kIsPagedKV
-                  kHasUnevenSplits,
-                  occupancy>;
+            using FmhaTraits = ck_tile::TileFmhaFwdSplitKVTraits<
+                kPadSeqLenQ,
+                kPadSeqLenK,
+                kPadHeadDim, // kPadHeadDimQ,
+                kPadHeadDim, // kPadHeadDimV,
+                kBiasEnum,
+                false, // kHasBiasGrad place-holder
+                true, // kStoreLSE
+                false, // kDoFp8StaticQuant place-holder
+                false, // kIsPagedKV
+                kHasUnevenSplits,
+                occupancy>;
 
+            if (param.num_kv_splits > 1) {
               using ODataType =
                   typename FmhaFwdTypeConfig<ScalarType>::OaccDataType;
               using FmhaPipelineProblem = FmhaFwdSplitKVPipelineProblemTemp<
@@ -116,8 +114,9 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
                   FmhaMask,
                   ODataType>;
 
-              using FmhaPipeline = ck_tile::BlockFmhaFwdSplitKVPipelineQRKSVS<
-                  FmhaPipelineProblem>;
+              using FmhaPipeline =
+                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                      FmhaPipelineProblem>;
 
               using FmhaEpilogue =
                   ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -133,19 +132,6 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
 
               RunWithFwdSplitKVKernel<FmhaKernel>(param, stream);
             } else {
-              using FmhaTraits = ck_tile::TileFmhaFwdSplitKVTraits<
-                  kPadSeqLenQ,
-                  kPadSeqLenK,
-                  kPadHeadDim, // kPadHeadDimQ,
-                  kPadHeadDim, // kPadHeadDimV,
-                  kBiasEnum,
-                  false, // kHasBiasGrad place-holder
-                  false, // kStoreLSE
-                  false, // kDoFp8StaticQuant place-holder
-                  false, // kIsPagedKV
-                  kHasUnevenSplits,
-                  occupancy>;
-
               using ODataType =
                   typename FmhaFwdTypeConfig<ScalarType>::ODataType;
               using FmhaPipelineProblem = FmhaFwdSplitKVPipelineProblemTemp<
@@ -153,8 +139,9 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
                   FmhaMask,
                   ODataType>;
 
-              using FmhaPipeline = ck_tile::BlockFmhaFwdSplitKVPipelineQRKSVS<
-                  FmhaPipelineProblem>;
+              using FmhaPipeline =
+                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                      FmhaPipelineProblem>;
 
               using FmhaEpilogue =
                   ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -171,13 +158,12 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
               RunWithFwdSplitKVKernel<FmhaKernel>(param, stream);
             }
           });
-    };
+    }
 
     if (param.num_kv_splits > 1) {
-      using FmhaTileShape =
-          typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type;
+      using FmhaTileShape = typename FmhaFwdSplitKVSmallQShape<MaxK>::Type;
 
-      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0 / 2;
+      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0;
       constexpr ck_tile::index_t kN1 = FmhaTileShape::kN1 / 2;
 
       using FmhaTilePartitioner =
@@ -194,7 +180,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
                   using FmhaTraits = ck_tile::TileFmhaFwdSplitKVCombineTraits<
                       kPadSeqLenQ,
                       kPadHeadDimV,
-                      false, // kStoreLSE
+                      true, // kStoreLSE
                       false, // kDoFp8StaticQuant place-holder
                       kLogMaxSplits,
                       -1>;
@@ -232,7 +218,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
       BatchedForwardParams& param,
       hipStream_t stream) {
     const auto kargs = [&] {
-      if (param.num_kv_splits > 1)
+      if (param.num_kv_splits)
         return FmhaFwdSplitKVKernel::MakeKargs(
             param.q_ptr,
             param.k_ptr,
@@ -287,7 +273,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
             param.k_ptr,
             param.v_ptr,
             param.attn_bias_ptr,
-            nullptr, // lse_ptr
+            param.logsumexp_ptr,
             param.out_ptr,
             param.B, // batch
             param.M, // seqlen_q
@@ -314,14 +300,14 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
             param.k_strides[2],
             param.v_strides[2],
             param.attn_bias_strides[1],
-            0, // nhead_stride_lse
+            param.lse_strides[1],
             param.out_strides[2],
             param.q_strides[0], // q, k, v, bias, lse, out tensor
                                 // batch-dim stride
             param.k_strides[0],
             param.v_strides[0],
             param.attn_bias_strides[0],
-            0, // batch_stride_lse
+            param.lse_strides[0],
             param.out_strides[0],
             0, // split_stride_lse_acc
             0, // split_stride_out_acc
@@ -350,7 +336,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
       return FmhaSplitKVCombineKernel::MakeKargs(
           param.logsumexp_acc_ptr,
           param.out_acc_ptr,
-          nullptr, // lse_ptr, not used
+          param.logsumexp_ptr,
           param.out_ptr,
           param.B, // batches
           param.M, // seqlen_q
@@ -361,11 +347,11 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
           param.out_strides[1], // row_stride_o
           param.lse_acc_strides[2], // head_stride_lse_acc
           param.out_acc_strides[3], // head_stride_o_acc
-          0, // head_stride_lse, // not used
+          param.lse_strides[1], // head_stride_lse
           param.out_strides[2], // head_stride_o
           param.lse_acc_strides[1], // batch_stride_lse_acc
           param.out_acc_strides[1], // batch_stride_o_acc
-          0, // batch_stride_lse, not used
+          param.lse_strides[0], // batch_stride_lse
           param.out_strides[0], // batch_stride_o
           param.lse_acc_strides[0], // split_stride_lse_acc
           param.out_acc_strides[0]); // split_stride_out_acc

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
@@ -25,7 +25,6 @@ void run_batched_infer_mask_bias_dropout_dispatch(
     hipStream_t stream) {
   // currently split-kv implementation does not support dropout
   if constexpr (!kHasDropout) {
-#ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
       if (use_splitkv_smallq(param.M, std::max(param.K, param.Kv))) {
         batched_infer_splitkv_smallq_mask_bias_dropout_dispatch<
@@ -44,7 +43,6 @@ void run_batched_infer_mask_bias_dropout_dispatch(
         });
       }
     } else {
-#endif
       if (get_fmha_fwd_mtile(param.B, param.Hq, param.M) == 128)
         batched_infer_mask_bias_dropout_dispatch<
             ScalarType,

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
@@ -6,8 +6,11 @@
  */
 #pragma once
 
+#include <algorithm>
 #include "ck_tiled_fmha_batched_infer_dispatch.h"
 #include "ck_tiled_fmha_batched_infer_splitkv_dispatch.h"
+#include "ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h"
+#include "ck_tiled_fmha_fwd_splitkv_selector.h"
 #include "ck_tiled_fmha_seqlen_q_switch.h"
 
 template <
@@ -23,14 +26,22 @@ void run_batched_infer_mask_bias_dropout_dispatch(
   if constexpr (!kHasDropout) {
 #ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
-      FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
-        batched_infer_splitkv_mask_bias_dropout_dispatch<
+      if (use_splitkv_smallq(param.M, std::max(param.K, param.Kv))) {
+        batched_infer_splitkv_smallq_mask_bias_dropout_dispatch<
             ScalarType,
             kHasMask,
             kHasBias,
-            MaxK,
-            MaxSeqlenQ>::Run(param, stream);
-      });
+            MaxK>::Run(param, stream);
+      } else {
+        FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
+          batched_infer_splitkv_mask_bias_dropout_dispatch<
+              ScalarType,
+              kHasMask,
+              kHasBias,
+              MaxK,
+              MaxSeqlenQ>::Run(param, stream);
+        });
+      }
     } else
 #endif
       batched_infer_mask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer.h
@@ -10,7 +10,8 @@
 #include "ck_tiled_fmha_batched_infer_dispatch.h"
 #include "ck_tiled_fmha_batched_infer_splitkv_dispatch.h"
 #include "ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h"
-#include "ck_tiled_fmha_fwd_splitkv_selector.h"
+#include "ck_tiled_fmha_fwd_setting.h"
+#include "ck_tiled_fmha_fwd_splitkv_smallq_selector.h"
 #include "ck_tiled_fmha_seqlen_q_switch.h"
 
 template <
@@ -42,20 +43,33 @@ void run_batched_infer_mask_bias_dropout_dispatch(
               MaxSeqlenQ>::Run(param, stream);
         });
       }
-    } else
+    } else {
 #endif
-      batched_infer_mask_bias_dropout_dispatch<
-          ScalarType,
-          kHasMask,
-          kHasBias,
-          kHasDropout,
-          MaxK>::Run(param, stream);
+      if (get_fmha_fwd_mtile(param.B, param.Hq, param.M) == 128)
+        batched_infer_mask_bias_dropout_dispatch<
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK,
+            128>::Run(param, stream);
+      else
+        batched_infer_mask_bias_dropout_dispatch<
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK,
+            64>::Run(param, stream);
+    }
   } else {
+    // at present, dropout of fwd kernel requires 32x32 WarpTile
     batched_infer_mask_bias_dropout_dispatch<
         ScalarType,
         kHasMask,
         kHasBias,
         kHasDropout,
-        MaxK>::Run(param, stream);
+        MaxK,
+        128>::Run(param, stream);
   }
 };

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_dispatch.h
@@ -45,19 +45,15 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
           FmhaMask,
           FmhaFwdSplitKVTraits>;
 
-  template <
-      ck_tile::index_t kM0,
-      ck_tile::index_t kN1,
-      typename FmhaSplitKVCombineTraits>
+  template <ck_tile::index_t kN1, typename FmhaSplitKVCombineTraits>
   using FmhaSplitKVCombinePipelineProblemTemp =
       ck_tile::BlockFmhaSplitKVCombinePipelineProblem<
           typename FmhaFwdTypeConfig<ScalarType>::LSEDataType,
           typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
           typename FmhaFwdTypeConfig<ScalarType>::ODataType,
           MaxK, // headdim_v
-          kM0,
-          kN1,
           false, // kIsGroupMode
+          kN1,
           FmhaSplitKVCombineTraits>;
 
   static void Run(BatchedForwardParams& param, hipStream_t stream) {
@@ -177,8 +173,11 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
       using FmhaTileShape =
           typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type;
 
-      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0 / 2;
-      constexpr ck_tile::index_t kN1 = FmhaTileShape::kN1 / 2;
+      constexpr ck_tile::index_t kN1 = 32;
+      constexpr ck_tile::index_t kM0 =
+          ck_tile::BlockFmhaSplitKVCombinePipelineTileSizes<
+              typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+              kN1>::kM0;
 
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVCombineTilePartitioner<kM0, kN1>;
@@ -200,10 +199,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
                       -1>;
 
                   using FmhaPipelineProblem =
-                      FmhaSplitKVCombinePipelineProblemTemp<
-                          kM0,
-                          kN1,
-                          FmhaTraits>;
+                      FmhaSplitKVCombinePipelineProblemTemp<kN1, FmhaTraits>;
 
                   using FmhaPipeline =
                       ck_tile::BlockFmhaFwdSplitKVCombinePipeline<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h
@@ -13,7 +13,7 @@
 #include <ck_tile/ops/fmha.hpp>
 
 #include "ck_tiled_bool_switch.h"
-#include "ck_tiled_fmha_fwd_splitkv_setting.h"
+#include "ck_tiled_fmha_fwd_splitkv_smallq_setting.h"
 #include "ck_tiled_fmha_num_kv_split_switch.h"
 #include "ck_tiled_fmha_params.h"
 
@@ -21,9 +21,8 @@ template <
     typename ScalarType,
     bool kHasMask,
     bool kHasBias,
-    ck_tile::index_t MaxK,
-    ck_tile::index_t MaxSeqlenQ>
-struct batched_infer_splitkv_mask_bias_dropout_dispatch {
+    ck_tile::index_t MaxK>
+struct batched_infer_splitkv_smallq_mask_bias_dropout_dispatch {
   template <
       typename FmhaFwdSplitKVTraits,
       typename FmhaMask,
@@ -40,7 +39,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
           typename FmhaFwdTypeConfig<ScalarType>::PDataType,
           typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
           ODataType,
-          typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type,
+          typename FmhaFwdSplitKVSmallQShape<MaxK>::Type,
           false, // kIsGroupMode
           FmhaMask,
           FmhaFwdSplitKVTraits>;
@@ -64,8 +63,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
     {
       using FmhaMask = ck_tile::SimplifiedGenericAttentionMask<kHasMask>;
 
-      using FmhaTileShape =
-          typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type;
+      using FmhaTileShape = typename FmhaFwdSplitKVSmallQShape<MaxK>::Type;
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVTilePartitioner<FmhaTileShape>;
       constexpr ck_tile::index_t occupancy = -1;
@@ -116,8 +114,9 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
                   FmhaMask,
                   ODataType>;
 
-              using FmhaPipeline = ck_tile::BlockFmhaFwdSplitKVPipelineQRKSVS<
-                  FmhaPipelineProblem>;
+              using FmhaPipeline =
+                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                      FmhaPipelineProblem>;
 
               using FmhaEpilogue =
                   ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -153,8 +152,9 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
                   FmhaMask,
                   ODataType>;
 
-              using FmhaPipeline = ck_tile::BlockFmhaFwdSplitKVPipelineQRKSVS<
-                  FmhaPipelineProblem>;
+              using FmhaPipeline =
+                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                      FmhaPipelineProblem>;
 
               using FmhaEpilogue =
                   ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -174,10 +174,9 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
     };
 
     if (param.num_kv_splits > 1) {
-      using FmhaTileShape =
-          typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type;
+      using FmhaTileShape = typename FmhaFwdSplitKVSmallQShape<MaxK>::Type;
 
-      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0 / 2;
+      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0;
       constexpr ck_tile::index_t kN1 = FmhaTileShape::kN1 / 2;
 
       using FmhaTilePartitioner =

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h
@@ -111,7 +111,7 @@ struct batched_infer_splitkv_smallq_mask_bias_dropout_dispatch {
                   ODataType>;
 
               using FmhaPipeline =
-                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                  ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
                       FmhaPipelineProblem>;
 
               using FmhaEpilogue =
@@ -149,7 +149,7 @@ struct batched_infer_splitkv_smallq_mask_bias_dropout_dispatch {
                   ODataType>;
 
               using FmhaPipeline =
-                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                  ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
                       FmhaPipelineProblem>;
 
               using FmhaEpilogue =

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_smallq_dispatch.h
@@ -44,19 +44,15 @@ struct batched_infer_splitkv_smallq_mask_bias_dropout_dispatch {
           FmhaMask,
           FmhaFwdSplitKVTraits>;
 
-  template <
-      ck_tile::index_t kM0,
-      ck_tile::index_t kN1,
-      typename FmhaSplitKVCombineTraits>
+  template <ck_tile::index_t kN1, typename FmhaSplitKVCombineTraits>
   using FmhaSplitKVCombinePipelineProblemTemp =
       ck_tile::BlockFmhaSplitKVCombinePipelineProblem<
           typename FmhaFwdTypeConfig<ScalarType>::LSEDataType,
           typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
           typename FmhaFwdTypeConfig<ScalarType>::ODataType,
           MaxK, // headdim_v
-          kM0,
-          kN1,
           false, // kIsGroupMode
+          kN1,
           FmhaSplitKVCombineTraits>;
 
   static void Run(BatchedForwardParams& param, hipStream_t stream) {
@@ -176,8 +172,11 @@ struct batched_infer_splitkv_smallq_mask_bias_dropout_dispatch {
     if (param.num_kv_splits > 1) {
       using FmhaTileShape = typename FmhaFwdSplitKVSmallQShape<MaxK>::Type;
 
-      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0;
-      constexpr ck_tile::index_t kN1 = FmhaTileShape::kN1 / 2;
+      constexpr ck_tile::index_t kN1 = 32;
+      constexpr ck_tile::index_t kM0 =
+          ck_tile::BlockFmhaSplitKVCombinePipelineTileSizes<
+              typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+              kN1>::kM0;
 
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVCombineTilePartitioner<kM0, kN1>;
@@ -199,10 +198,7 @@ struct batched_infer_splitkv_smallq_mask_bias_dropout_dispatch {
                       -1>;
 
                   using FmhaPipelineProblem =
-                      FmhaSplitKVCombinePipelineProblemTemp<
-                          kM0,
-                          kN1,
-                          FmhaTraits>;
+                      FmhaSplitKVCombinePipelineProblemTemp<kN1, FmhaTraits>;
 
                   using FmhaPipeline =
                       ck_tile::BlockFmhaFwdSplitKVCombinePipeline<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_setting.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_setting.h
@@ -8,101 +8,164 @@
 
 #include <ck_tile/core.hpp>
 #include <ck_tile/ops/fmha.hpp>
+#include "ck_fmha_util.h"
 #include "ck_tiled_fmha_fwd_type_config.h"
 
-template <ck_tile::index_t MaxK>
+template <ck_tile::index_t MaxK, ck_tile::index_t MTile = 0>
 struct FmhaFwdBlockTile;
 
 // Tile-sizes: M N0 K0 N1 K1 MaxK (MaxK % K0 == 0, MaxK % N1 == 0, N0 % K1 == 0)
 //
-template <>
-struct FmhaFwdBlockTile<32> {
-  using type = ck_tile::sequence<128, 64, 16, 32, 32, 32>;
+template <ck_tile::index_t MTile>
+struct FmhaFwdBlockTile<32, MTile> {
+  using type = ck_tile::sequence<64, 64, 16, 32, 32, 32>;
   using gemm0_warps = ck_tile::sequence<2, 1, 1>;
   using gemm1_warps = ck_tile::sequence<2, 1, 1>;
 };
 
-template <>
-struct FmhaFwdBlockTile<64> {
+template struct FmhaFwdBlockTile<32>;
+
+template <ck_tile::index_t MTile>
+struct FmhaFwdBlockTile<64, MTile> {
   using type = ck_tile::sequence<128, 64, 32, 64, 32, 64>;
   using gemm0_warps = ck_tile::sequence<4, 1, 1>;
   using gemm1_warps = ck_tile::sequence<4, 1, 1>;
 };
 
-template <>
-struct FmhaFwdBlockTile<96> {
+template struct FmhaFwdBlockTile<64>;
+
+template <ck_tile::index_t MTile>
+struct FmhaFwdBlockTile<96, MTile> {
   using type = ck_tile::sequence<128, 128, 32, 128, 32, 96>;
   using gemm0_warps = ck_tile::sequence<4, 1, 1>;
   using gemm1_warps = ck_tile::sequence<4, 1, 1>;
 };
 
+template struct FmhaFwdBlockTile<96>;
+
 template <>
-struct FmhaFwdBlockTile<128> {
+struct FmhaFwdBlockTile<128, 64> {
+  using type = ck_tile::sequence<64, 128, 32, 128, 32, 128>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<4, 1, 1>;
+};
+
+template <>
+struct FmhaFwdBlockTile<128, 128> {
   using type = ck_tile::sequence<128, 128, 32, 128, 32, 128>;
   using gemm0_warps = ck_tile::sequence<4, 1, 1>;
   using gemm1_warps = ck_tile::sequence<4, 1, 1>;
 };
 
-template <>
-struct FmhaFwdBlockTile<256> {
+template <ck_tile::index_t MTile>
+struct FmhaFwdBlockTile<256, MTile> {
   using type = ck_tile::sequence<128, 128, 32, 256, 32, 256>;
   using gemm0_warps = ck_tile::sequence<4, 1, 1>;
   using gemm1_warps = ck_tile::sequence<4, 1, 1>;
 };
 
-using FmhaFwdWarpTile = ck_tile::sequence<32, 32, 16>;
+template struct FmhaFwdBlockTile<256>;
 
-template <ck_tile::index_t MaxK>
+using FmhaFwdWarpTile1 = ck_tile::sequence<32, 32, 16>;
+using FmhaFwdWarpTile2 = ck_tile::sequence<16, 16, 16>;
+
+template <ck_tile::index_t MaxK, ck_tile::index_t MTile>
 struct FmhaFwdShape;
 
-template <>
-struct FmhaFwdShape<32> : ck_tile::TileFmhaShape<
-                              typename FmhaFwdBlockTile<32>::type,
-                              typename FmhaFwdBlockTile<32>::gemm0_warps,
-                              FmhaFwdWarpTile,
-                              typename FmhaFwdBlockTile<32>::gemm1_warps,
-                              FmhaFwdWarpTile,
-                              IsVLayoutRowMajor> {};
+template <ck_tile::index_t MTile>
+struct FmhaFwdShape<32, MTile> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdBlockTile<32>::type,
+      typename FmhaFwdBlockTile<32>::gemm0_warps,
+      FmhaFwdWarpTile1,
+      typename FmhaFwdBlockTile<32>::gemm1_warps,
+      FmhaFwdWarpTile1,
+      IsVLayoutRowMajor>;
+};
+
+template struct FmhaFwdShape<32, 64>;
+template struct FmhaFwdShape<32, 128>;
+
+template <ck_tile::index_t MTile>
+struct FmhaFwdShape<64, MTile> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdBlockTile<64>::type,
+      typename FmhaFwdBlockTile<64>::gemm0_warps,
+      FmhaFwdWarpTile1,
+      typename FmhaFwdBlockTile<64>::gemm1_warps,
+      FmhaFwdWarpTile1,
+      IsVLayoutRowMajor>;
+};
+
+template struct FmhaFwdShape<64, 64>;
+template struct FmhaFwdShape<64, 128>;
+
+template <ck_tile::index_t MTile>
+struct FmhaFwdShape<96, MTile> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdBlockTile<96>::type,
+      typename FmhaFwdBlockTile<96>::gemm0_warps,
+      FmhaFwdWarpTile1,
+      typename FmhaFwdBlockTile<96>::gemm1_warps,
+      FmhaFwdWarpTile1,
+      IsVLayoutRowMajor>;
+};
+
+template struct FmhaFwdShape<96, 64>;
+template struct FmhaFwdShape<96, 128>;
 
 template <>
-struct FmhaFwdShape<64> : ck_tile::TileFmhaShape<
-                              typename FmhaFwdBlockTile<64>::type,
-                              typename FmhaFwdBlockTile<64>::gemm0_warps,
-                              FmhaFwdWarpTile,
-                              typename FmhaFwdBlockTile<64>::gemm1_warps,
-                              FmhaFwdWarpTile,
-                              IsVLayoutRowMajor> {};
+struct FmhaFwdShape<128, 64> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdBlockTile<128, 64>::type,
+      typename FmhaFwdBlockTile<128, 64>::gemm0_warps,
+      FmhaFwdWarpTile2,
+      typename FmhaFwdBlockTile<128, 64>::gemm1_warps,
+      FmhaFwdWarpTile2,
+      IsVLayoutRowMajor>;
+};
 
 template <>
-struct FmhaFwdShape<96> : ck_tile::TileFmhaShape<
-                              typename FmhaFwdBlockTile<96>::type,
-                              typename FmhaFwdBlockTile<96>::gemm0_warps,
-                              FmhaFwdWarpTile,
-                              typename FmhaFwdBlockTile<96>::gemm1_warps,
-                              FmhaFwdWarpTile,
-                              IsVLayoutRowMajor> {};
+struct FmhaFwdShape<128, 128> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdBlockTile<128, 128>::type,
+      typename FmhaFwdBlockTile<128, 128>::gemm0_warps,
+      FmhaFwdWarpTile1,
+      typename FmhaFwdBlockTile<128, 128>::gemm1_warps,
+      FmhaFwdWarpTile1,
+      IsVLayoutRowMajor>;
+};
 
-template <>
-struct FmhaFwdShape<128> : ck_tile::TileFmhaShape<
-                               typename FmhaFwdBlockTile<128>::type,
-                               typename FmhaFwdBlockTile<128>::gemm0_warps,
-                               FmhaFwdWarpTile,
-                               typename FmhaFwdBlockTile<128>::gemm1_warps,
-                               FmhaFwdWarpTile,
-                               IsVLayoutRowMajor> {};
+template <ck_tile::index_t MTile>
+struct FmhaFwdShape<256, MTile> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdBlockTile<256>::type,
+      typename FmhaFwdBlockTile<256>::gemm0_warps,
+      FmhaFwdWarpTile1,
+      typename FmhaFwdBlockTile<256>::gemm1_warps,
+      FmhaFwdWarpTile1,
+      IsVLayoutRowMajor>;
+};
 
-template <>
-struct FmhaFwdShape<256> : ck_tile::TileFmhaShape<
-                               typename FmhaFwdBlockTile<256>::type,
-                               typename FmhaFwdBlockTile<256>::gemm0_warps,
-                               FmhaFwdWarpTile,
-                               typename FmhaFwdBlockTile<256>::gemm1_warps,
-                               FmhaFwdWarpTile,
-                               IsVLayoutRowMajor> {};
+template struct FmhaFwdShape<256, 64>;
+template struct FmhaFwdShape<256, 128>;
 
-template <ck_tile::index_t MaxK>
-int fwd_get_mtile_size() {
-  using FmhaTileShape = FmhaFwdShape<MaxK>;
+static int get_fmha_fwd_mtile(
+    int num_batches,
+    int num_heads,
+    int max_seqlen_q) {
+  int num_SMs = get_number_of_cu();
+  auto ceildiv = [](int a, int b) { return (a + b - 1) / b; };
 
-  return FmhaTileShape::kM0;
+  int batch_nhead_mblocks =
+      num_batches * num_heads * ceildiv(max_seqlen_q, 128);
+
+  if (batch_nhead_mblocks >= 0.8 * num_SMs)
+    return 128;
+
+  return 64;
+};
+
+static int get_fmha_fwd_least_mtile() {
+  return 64;
 };

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_selector.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_selector.h
@@ -71,7 +71,7 @@ static std::pair<bool, int> get_num_kv_splits_heuristic(
     int batch_nhead_mblocks = num_batches * num_heads *
         ceildiv(max_seqlen_q, mtile_size_for_pipeline_default);
 
-    if (batch_nhead_mblocks >= 0.8f * num_SMs)
+    if (batch_nhead_mblocks >= 0.8 * num_SMs)
       return std::make_pair(false, 1);
   }
 
@@ -89,7 +89,7 @@ static std::pair<bool, int> get_num_kv_splits_heuristic(
       num_batches * num_heads * ceildiv(max_seqlen_q, mtile_size);
 
   // If we have enough to almost fill the SMs, then just use 1 split
-  if (batch_nhead_mblocks >= 0.8f * num_SMs) {
+  if (batch_nhead_mblocks >= num_SMs) {
     return std::make_pair(use_splitkv, 1);
   }
 
@@ -128,7 +128,7 @@ static std::pair<bool, int> get_num_kv_splits_heuristic(
   for (int i = 1; i < max_check; i++) {
     num_splits = generate_splits_list(i);
 
-    if (batch_nhead_mblocks * num_splits >= 0.8 * num_SMs)
+    if (batch_nhead_mblocks * num_splits >= num_SMs)
       break;
   };
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_setting.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_setting.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <ck_tile/core.hpp>
+#include <ck_tile/ops/fmha.hpp>
+#include "ck_tiled_fmha_fwd_type_config.h"
+
+template <ck_tile::index_t MaxK, ck_tile::index_t MaxSeqLenQ = 0>
+struct FmhaFwdSplitKVBlockTile;
+
+// Tile-sizes: M N0 K0 N1 K1 MaxK (MaxK % K0 == 0, MaxK % N1 == 0, N0 % K1 == 0)
+
+template <ck_tile::index_t MaxSeqLenQ>
+struct FmhaFwdSplitKVBlockTile<32, MaxSeqLenQ> {
+  using type = ck_tile::sequence<32, 64, 16, 32, 32, 32>;
+  using gemm0_warps = ck_tile::sequence<2, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<2, 1, 1>;
+};
+
+template struct FmhaFwdSplitKVBlockTile<32>;
+
+template <ck_tile::index_t MaxSeqLenQ>
+struct FmhaFwdSplitKVBlockTile<64, MaxSeqLenQ> {
+  using type = ck_tile::sequence<32, 64, 32, 64, 32, 64>;
+  using gemm0_warps = ck_tile::sequence<2, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<2, 1, 1>;
+};
+
+template struct FmhaFwdSplitKVBlockTile<64>;
+
+template <ck_tile::index_t MaxSeqLenQ>
+struct FmhaFwdSplitKVBlockTile<96, MaxSeqLenQ> {
+  using type = ck_tile::sequence<64, 128, 32, 128, 32, 96>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<4, 1, 1>;
+};
+
+template struct FmhaFwdSplitKVBlockTile<96>;
+
+template <>
+struct FmhaFwdSplitKVBlockTile<128, 32> {
+  using type = ck_tile::sequence<32, 128, 32, 128, 32, 128>;
+  using gemm0_warps = ck_tile::sequence<2, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<2, 1, 1>;
+};
+
+template <>
+struct FmhaFwdSplitKVBlockTile<128, 64> {
+  using type = ck_tile::sequence<64, 128, 32, 128, 32, 128>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<4, 1, 1>;
+};
+
+template <ck_tile::index_t MaxSeqLenQ>
+struct FmhaFwdSplitKVBlockTile<256, MaxSeqLenQ> {
+  using type = ck_tile::sequence<64, 128, 32, 256, 32, 256>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<4, 1, 1>;
+};
+
+template struct FmhaFwdSplitKVBlockTile<256>;
+
+using FmhaFwdSplitKVWarpTile = ck_tile::sequence<16, 16, 16>;
+
+template <ck_tile::index_t MaxK, ck_tile::index_t MaxSeqLenQ>
+struct FmhaFwdSplitKVShape;
+
+template <ck_tile::index_t MaxSeqLenQ>
+struct FmhaFwdSplitKVShape<32, MaxSeqLenQ> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVBlockTile<32>::type,
+      typename FmhaFwdSplitKVBlockTile<32>::gemm0_warps,
+      FmhaFwdSplitKVWarpTile,
+      typename FmhaFwdSplitKVBlockTile<32>::gemm1_warps,
+      FmhaFwdSplitKVWarpTile,
+      IsVLayoutRowMajor>;
+};
+
+template struct FmhaFwdSplitKVShape<32, 32>;
+template struct FmhaFwdSplitKVShape<32, 64>;
+
+template <ck_tile::index_t MaxSeqLenQ>
+struct FmhaFwdSplitKVShape<64, MaxSeqLenQ> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVBlockTile<64>::type,
+      typename FmhaFwdSplitKVBlockTile<64>::gemm0_warps,
+      FmhaFwdSplitKVWarpTile,
+      typename FmhaFwdSplitKVBlockTile<64, MaxSeqLenQ>::gemm1_warps,
+      FmhaFwdSplitKVWarpTile,
+      IsVLayoutRowMajor>;
+};
+
+template struct FmhaFwdSplitKVShape<64, 32>;
+template struct FmhaFwdSplitKVShape<64, 64>;
+
+template <ck_tile::index_t MaxSeqLenQ>
+struct FmhaFwdSplitKVShape<96, MaxSeqLenQ> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVBlockTile<96>::type,
+      typename FmhaFwdSplitKVBlockTile<96>::gemm0_warps,
+      FmhaFwdSplitKVWarpTile,
+      typename FmhaFwdSplitKVBlockTile<96, MaxSeqLenQ>::gemm1_warps,
+      FmhaFwdSplitKVWarpTile,
+      IsVLayoutRowMajor>;
+};
+
+template struct FmhaFwdSplitKVShape<96, 32>;
+template struct FmhaFwdSplitKVShape<96, 64>;
+
+template <>
+struct FmhaFwdSplitKVShape<128, 32> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVBlockTile<128, 32>::type,
+      typename FmhaFwdSplitKVBlockTile<128, 32>::gemm0_warps,
+      FmhaFwdSplitKVWarpTile,
+      typename FmhaFwdSplitKVBlockTile<128, 32>::gemm1_warps,
+      FmhaFwdSplitKVWarpTile,
+      IsVLayoutRowMajor>;
+};
+
+template <>
+struct FmhaFwdSplitKVShape<128, 64> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVBlockTile<128, 64>::type,
+      typename FmhaFwdSplitKVBlockTile<128, 64>::gemm0_warps,
+      FmhaFwdSplitKVWarpTile,
+      typename FmhaFwdSplitKVBlockTile<128, 64>::gemm1_warps,
+      FmhaFwdSplitKVWarpTile,
+      IsVLayoutRowMajor>;
+};
+
+template <ck_tile::index_t MaxSeqLenQ>
+struct FmhaFwdSplitKVShape<256, MaxSeqLenQ> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVBlockTile<256>::type,
+      typename FmhaFwdSplitKVBlockTile<256>::gemm0_warps,
+      FmhaFwdSplitKVWarpTile,
+      typename FmhaFwdSplitKVBlockTile<256>::gemm1_warps,
+      FmhaFwdSplitKVWarpTile,
+      IsVLayoutRowMajor>;
+};
+
+template struct FmhaFwdSplitKVShape<256, 32>;
+template struct FmhaFwdSplitKVShape<256, 64>;
+
+template <ck_tile::index_t MaxK, ck_tile::index_t MaxSeqLenQ>
+int fwd_splitkv_get_mtile_size() {
+  using FmhaTileShape = typename FmhaFwdSplitKVShape<MaxK, MaxSeqLenQ>::Type;
+
+  return FmhaTileShape::kM0;
+};

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_selector.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_selector.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include "ck_tiled_fmha_fwd_splitkv_smallq_setting.h"
+
+static bool use_splitkv_smallq(int max_seqlen_q, int max_headdim) {
+  int mtile_size_for_splitkv_smallq = 16;
+
+  // get mtile_size_for_splitkv_smallq
+  if (max_headdim <= 32) {
+    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<32>();
+  } else if (max_headdim <= 64) {
+    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<64>();
+  } else if (max_headdim <= 96) {
+    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<96>();
+  } else if (max_headdim <= 128) {
+    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<128>();
+  } else {
+    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<256>();
+  };
+
+  if (max_seqlen_q <= mtile_size_for_splitkv_smallq)
+    return true;
+  else
+    return false;
+}

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_selector.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_selector.h
@@ -6,26 +6,17 @@
  */
 #pragma once
 
+#include "ck_tiled_fmha_fwd_splitkv_setting.h"
 #include "ck_tiled_fmha_fwd_splitkv_smallq_setting.h"
 
+/// This method determines whether to use normal or smallq splitkv kernel
 static bool use_splitkv_smallq(int max_seqlen_q, int max_headdim) {
-  int mtile_size_for_splitkv_smallq = 16;
+  int mtile_size_for_splitkv_smallq =
+      get_mtile_size_for_splitkv_smallq(max_headdim);
 
-  // get mtile_size_for_splitkv_smallq
-  if (max_headdim <= 32) {
-    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<32>();
-  } else if (max_headdim <= 64) {
-    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<64>();
-  } else if (max_headdim <= 96) {
-    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<96>();
-  } else if (max_headdim <= 128) {
-    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<128>();
-  } else {
-    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<256>();
-  };
-
+  // resort to splitkv-smallq kernel for avoiding wasting of computation
   if (max_seqlen_q <= mtile_size_for_splitkv_smallq)
     return true;
-  else
-    return false;
+
+  return false;
 }

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_setting.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_setting.h
@@ -38,14 +38,14 @@ struct FmhaFwdSplitKVSmallQBlockTile<96> {
 
 template <>
 struct FmhaFwdSplitKVSmallQBlockTile<128> {
-  using type = ck_tile::sequence<16, 64, 32, 128, 64, 128>;
+  using type = ck_tile::sequence<16, 64, 64, 128, 64, 128>;
   using gemm0_warps = ck_tile::sequence<1, 4, 1>;
   using gemm1_warps = ck_tile::sequence<1, 4, 1>;
 };
 
 template <>
 struct FmhaFwdSplitKVSmallQBlockTile<256> {
-  using type = ck_tile::sequence<16, 64, 32, 256, 32, 256>;
+  using type = ck_tile::sequence<16, 64, 64, 256, 64, 256>;
   using gemm0_warps = ck_tile::sequence<1, 4, 1>;
   using gemm1_warps = ck_tile::sequence<1, 4, 1>;
 };

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_setting.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_setting.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <ck_tile/core.hpp>
+#include <ck_tile/ops/fmha.hpp>
+#include "ck_tiled_fmha_fwd_type_config.h"
+
+template <ck_tile::index_t MaxK>
+struct FmhaFwdSplitKVSmallQBlockTile;
+
+// Tile-sizes: M N0 K0 N1 K1 MaxK (MaxK % K0 == 0, MaxK % N1 == 0, N0 % K1 == 0)
+
+template <>
+struct FmhaFwdSplitKVSmallQBlockTile<32> {
+  using type = ck_tile::sequence<16, 64, 16, 32, 32, 32>;
+  using gemm0_warps = ck_tile::sequence<2, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<1, 2, 1>;
+};
+
+template <>
+struct FmhaFwdSplitKVSmallQBlockTile<64> {
+  using type = ck_tile::sequence<16, 64, 32, 64, 32, 64>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<1, 4, 1>;
+};
+
+template <>
+struct FmhaFwdSplitKVSmallQBlockTile<96> {
+  using type = ck_tile::sequence<16, 64, 32, 128, 16, 96>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<1, 4, 1>;
+};
+
+template <>
+struct FmhaFwdSplitKVSmallQBlockTile<128> {
+  using type = ck_tile::sequence<16, 64, 32, 128, 16, 128>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<1, 4, 1>;
+};
+
+template <>
+struct FmhaFwdSplitKVSmallQBlockTile<256> {
+  using type = ck_tile::sequence<16, 64, 32, 256, 16, 256>;
+  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm1_warps = ck_tile::sequence<1, 4, 1>;
+};
+
+using FmhaFwdSplitKVSmallQWarpTile0 = ck_tile::sequence<4, 64, 16>;
+using FmhaFwdSplitKVSmallQWarpTile1 = ck_tile::sequence<16, 16, 16>;
+
+template <ck_tile::index_t MaxK>
+struct FmhaFwdSplitKVSmallQShape;
+
+template <>
+struct FmhaFwdSplitKVSmallQShape<32> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVSmallQBlockTile<32>::type,
+      typename FmhaFwdSplitKVSmallQBlockTile<32>::gemm0_warps,
+      FmhaFwdSplitKVSmallQWarpTile0,
+      typename FmhaFwdSplitKVSmallQBlockTile<32>::gemm1_warps,
+      FmhaFwdSplitKVSmallQWarpTile1,
+      IsVLayoutRowMajor>;
+};
+
+template <>
+struct FmhaFwdSplitKVSmallQShape<64> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVSmallQBlockTile<64>::type,
+      typename FmhaFwdSplitKVSmallQBlockTile<64>::gemm0_warps,
+      FmhaFwdSplitKVSmallQWarpTile0,
+      typename FmhaFwdSplitKVSmallQBlockTile<64>::gemm1_warps,
+      FmhaFwdSplitKVSmallQWarpTile1,
+      IsVLayoutRowMajor>;
+};
+
+template <>
+struct FmhaFwdSplitKVSmallQShape<96> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVSmallQBlockTile<96>::type,
+      typename FmhaFwdSplitKVSmallQBlockTile<96>::gemm0_warps,
+      FmhaFwdSplitKVSmallQWarpTile0,
+      typename FmhaFwdSplitKVSmallQBlockTile<96>::gemm1_warps,
+      FmhaFwdSplitKVSmallQWarpTile1,
+      IsVLayoutRowMajor>;
+};
+
+template <>
+struct FmhaFwdSplitKVSmallQShape<128> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVSmallQBlockTile<128>::type,
+      typename FmhaFwdSplitKVSmallQBlockTile<128>::gemm0_warps,
+      FmhaFwdSplitKVSmallQWarpTile0,
+      typename FmhaFwdSplitKVSmallQBlockTile<128>::gemm1_warps,
+      FmhaFwdSplitKVSmallQWarpTile1,
+      IsVLayoutRowMajor>;
+};
+
+template <>
+struct FmhaFwdSplitKVSmallQShape<256> {
+  using Type = ck_tile::TileFmhaShape<
+      typename FmhaFwdSplitKVSmallQBlockTile<256>::type,
+      typename FmhaFwdSplitKVSmallQBlockTile<256>::gemm0_warps,
+      FmhaFwdSplitKVSmallQWarpTile0,
+      typename FmhaFwdSplitKVSmallQBlockTile<256>::gemm1_warps,
+      FmhaFwdSplitKVSmallQWarpTile1,
+      IsVLayoutRowMajor>;
+};
+
+template <ck_tile::index_t MaxK>
+int fwd_splitkv_smallq_get_mtile_size() {
+  using FmhaTileShape = typename FmhaFwdSplitKVSmallQShape<MaxK>::Type;
+
+  return FmhaTileShape::kM0;
+};

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_setting.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_setting.h
@@ -31,21 +31,21 @@ struct FmhaFwdSplitKVSmallQBlockTile<64> {
 
 template <>
 struct FmhaFwdSplitKVSmallQBlockTile<96> {
-  using type = ck_tile::sequence<16, 64, 32, 128, 16, 96>;
+  using type = ck_tile::sequence<16, 64, 32, 128, 32, 96>;
   using gemm0_warps = ck_tile::sequence<4, 1, 1>;
   using gemm1_warps = ck_tile::sequence<1, 4, 1>;
 };
 
 template <>
 struct FmhaFwdSplitKVSmallQBlockTile<128> {
-  using type = ck_tile::sequence<16, 64, 32, 128, 16, 128>;
+  using type = ck_tile::sequence<16, 64, 32, 128, 64, 128>;
   using gemm0_warps = ck_tile::sequence<4, 1, 1>;
   using gemm1_warps = ck_tile::sequence<1, 4, 1>;
 };
 
 template <>
 struct FmhaFwdSplitKVSmallQBlockTile<256> {
-  using type = ck_tile::sequence<16, 64, 32, 256, 16, 256>;
+  using type = ck_tile::sequence<16, 64, 32, 256, 32, 256>;
   using gemm0_warps = ck_tile::sequence<4, 1, 1>;
   using gemm1_warps = ck_tile::sequence<1, 4, 1>;
 };

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_setting.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_setting.h
@@ -117,3 +117,21 @@ int fwd_splitkv_smallq_get_mtile_size() {
 
   return FmhaTileShape::kM0;
 };
+
+static int get_mtile_size_for_splitkv_smallq(int max_headdim) {
+  int mtile_size_for_splitkv_smallq = 16;
+
+  if (max_headdim <= 32) {
+    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<32>();
+  } else if (max_headdim <= 64) {
+    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<64>();
+  } else if (max_headdim <= 96) {
+    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<96>();
+  } else if (max_headdim <= 128) {
+    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<128>();
+  } else {
+    mtile_size_for_splitkv_smallq = fwd_splitkv_smallq_get_mtile_size<256>();
+  };
+
+  return mtile_size_for_splitkv_smallq;
+};

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_setting.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_splitkv_smallq_setting.h
@@ -18,39 +18,39 @@ struct FmhaFwdSplitKVSmallQBlockTile;
 template <>
 struct FmhaFwdSplitKVSmallQBlockTile<32> {
   using type = ck_tile::sequence<16, 64, 16, 32, 32, 32>;
-  using gemm0_warps = ck_tile::sequence<2, 1, 1>;
+  using gemm0_warps = ck_tile::sequence<1, 2, 1>;
   using gemm1_warps = ck_tile::sequence<1, 2, 1>;
 };
 
 template <>
 struct FmhaFwdSplitKVSmallQBlockTile<64> {
   using type = ck_tile::sequence<16, 64, 32, 64, 32, 64>;
-  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm0_warps = ck_tile::sequence<1, 4, 1>;
   using gemm1_warps = ck_tile::sequence<1, 4, 1>;
 };
 
 template <>
 struct FmhaFwdSplitKVSmallQBlockTile<96> {
   using type = ck_tile::sequence<16, 64, 32, 128, 32, 96>;
-  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm0_warps = ck_tile::sequence<1, 4, 1>;
   using gemm1_warps = ck_tile::sequence<1, 4, 1>;
 };
 
 template <>
 struct FmhaFwdSplitKVSmallQBlockTile<128> {
   using type = ck_tile::sequence<16, 64, 32, 128, 64, 128>;
-  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm0_warps = ck_tile::sequence<1, 4, 1>;
   using gemm1_warps = ck_tile::sequence<1, 4, 1>;
 };
 
 template <>
 struct FmhaFwdSplitKVSmallQBlockTile<256> {
   using type = ck_tile::sequence<16, 64, 32, 256, 32, 256>;
-  using gemm0_warps = ck_tile::sequence<4, 1, 1>;
+  using gemm0_warps = ck_tile::sequence<1, 4, 1>;
   using gemm1_warps = ck_tile::sequence<1, 4, 1>;
 };
 
-using FmhaFwdSplitKVSmallQWarpTile0 = ck_tile::sequence<4, 64, 16>;
+using FmhaFwdSplitKVSmallQWarpTile0 = ck_tile::sequence<16, 16, 16>;
 using FmhaFwdSplitKVSmallQWarpTile1 = ck_tile::sequence<16, 16, 16>;
 
 template <ck_tile::index_t MaxK>

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_type_config.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_fwd_type_config.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023-2024, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#pragma once
+
+#include <ck_tile/core.hpp>
+
+template <typename DataType>
+struct FmhaFwdTypeConfig;
+
+template <>
+struct FmhaFwdTypeConfig<ck_tile::fp16_t> {
+  using QDataType = ck_tile::fp16_t;
+  using KDataType = ck_tile::fp16_t;
+  using VDataType = ck_tile::fp16_t;
+  using BiasDataType = ck_tile::fp16_t;
+  using RandValOutputDataType = unsigned short;
+  using LSEDataType =
+      float; // data type for lse(logsumexp L_j = max_j + log(l_j))
+  using SaccDataType = float; // data type for first gemm accumulation
+  using SMPLComputeDataType = float; // data type for reduction, softmax
+  using PDataType = ck_tile::fp16_t; // data type for A matrix of second gemm
+  using OaccDataType = float; // data type for second gemm accumulation
+  using ODataType = ck_tile::fp16_t;
+};
+
+template <>
+struct FmhaFwdTypeConfig<ck_tile::bf16_t> {
+  using QDataType = ck_tile::bf16_t;
+  using KDataType = ck_tile::bf16_t;
+  using VDataType = ck_tile::bf16_t;
+  using BiasDataType = ck_tile::bf16_t;
+  using RandValOutputDataType = unsigned short;
+  using LSEDataType =
+      float; // data type for lse(logsumexp L_j = max_j + log(l_j))
+  using SaccDataType = float; // data type for first gemm accumulation
+  using SMPLComputeDataType = float; // data type for reduction, softmax
+  using PDataType = ck_tile::bf16_t; // data type for A matrix of second gemm
+  using OaccDataType = float; // data type for second gemm accumulation
+  using ODataType = ck_tile::bf16_t;
+};
+
+static constexpr bool IsVLayoutRowMajor = true;

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
@@ -6,8 +6,11 @@
  */
 #pragma once
 
+#include <algorithm>
+#include "ck_tiled_fmha_fwd_splitkv_selector.h"
 #include "ck_tiled_fmha_grouped_forward_dispatch.h"
 #include "ck_tiled_fmha_grouped_forward_splitkv_dispatch.h"
+#include "ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h"
 #include "ck_tiled_fmha_seqlen_q_switch.h"
 
 template <
@@ -23,14 +26,22 @@ void run_grouped_forward_mask_bias_dropout_dispatch(
   if constexpr (!kHasDropout) {
 #ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
-      FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
-        grouped_forward_splitkv_mask_bias_dropout_dispatch<
+      if (use_splitkv_smallq(param.max_seqlen_q, std::max(param.K, param.Kv))) {
+        grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch<
             ScalarType,
             kHasMask,
             kHasBias,
-            MaxK,
-            MaxSeqlenQ>::Run(param, stream);
-      });
+            MaxK>::Run(param, stream);
+      } else {
+        FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
+          grouped_forward_splitkv_mask_bias_dropout_dispatch<
+              ScalarType,
+              kHasMask,
+              kHasBias,
+              MaxK,
+              MaxSeqlenQ>::Run(param, stream);
+        });
+      }
     } else
 #endif
       grouped_forward_mask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
@@ -25,7 +25,6 @@ void run_grouped_forward_mask_bias_dropout_dispatch(
     hipStream_t stream) {
   // currently split-kv implementation does not support dropout
   if constexpr (!kHasDropout) {
-#ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
       if (use_splitkv_smallq(param.max_seqlen_q, std::max(param.K, param.Kv))) {
         grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch<
@@ -43,9 +42,7 @@ void run_grouped_forward_mask_bias_dropout_dispatch(
               MaxSeqlenQ>::Run(param, stream);
         });
       }
-    } else
-#endif
-    {
+    } else {
       if (get_fmha_fwd_mtile(param.num_batches, param.Hq, param.max_seqlen_q) ==
           128)
         grouped_forward_mask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_dispatch.h
@@ -21,7 +21,8 @@ template <
     bool kHasMask,
     bool kHasBias,
     bool kHasDropout,
-    ck_tile::index_t MaxK>
+    ck_tile::index_t MaxK,
+    ck_tile::index_t MTile>
 struct grouped_forward_mask_bias_dropout_dispatch {
   template <typename FmhaTraits, typename FmhaMask>
   using FmhaPipelineProblemTemp = ck_tile::BlockFmhaPipelineProblem<
@@ -36,7 +37,7 @@ struct grouped_forward_mask_bias_dropout_dispatch {
       typename FmhaFwdTypeConfig<ScalarType>::PDataType,
       typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
       typename FmhaFwdTypeConfig<ScalarType>::ODataType,
-      FmhaFwdShape<MaxK>,
+      typename FmhaFwdShape<MaxK, MTile>::Type,
       true, // kIsGroupMode
       FmhaMask,
       FmhaTraits>;
@@ -44,7 +45,7 @@ struct grouped_forward_mask_bias_dropout_dispatch {
   static void Run(GroupedForwardParams& param, hipStream_t stream) {
     using FmhaMask = ck_tile::SimplifiedGenericAttentionMask<kHasMask>;
 
-    using FmhaFwdShape_ = FmhaFwdShape<MaxK>;
+    using FmhaFwdShape_ = typename FmhaFwdShape<MaxK, MTile>::Type;
 
     constexpr ck_tile::index_t occupancy = (MaxK == 64) ? 3
         : (MaxK == 256)                                 ? 1

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_dispatch.h
@@ -45,19 +45,15 @@ struct grouped_forward_splitkv_mask_bias_dropout_dispatch {
           FmhaMask,
           FmhaFwdSplitKVTraits>;
 
-  template <
-      ck_tile::index_t kM0,
-      ck_tile::index_t kN1,
-      typename FmhaSplitKVCombineTraits>
+  template <ck_tile::index_t kN1, typename FmhaSplitKVCombineTraits>
   using FmhaSplitKVCombinePipelineProblemTemp =
       ck_tile::BlockFmhaSplitKVCombinePipelineProblem<
           typename FmhaFwdTypeConfig<ScalarType>::LSEDataType,
           typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
           typename FmhaFwdTypeConfig<ScalarType>::ODataType,
           MaxK, // headdim_v
-          kM0,
-          kN1,
           true, // kIsGroupMode
+          kN1,
           FmhaSplitKVCombineTraits>;
 
   static void Run(GroupedForwardParams& param, hipStream_t stream) {
@@ -154,8 +150,11 @@ struct grouped_forward_splitkv_mask_bias_dropout_dispatch {
       using FmhaTileShape =
           typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type;
 
-      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0 / 2;
-      constexpr ck_tile::index_t kN1 = FmhaTileShape::kN1 / 2;
+      constexpr ck_tile::index_t kN1 = 32;
+      constexpr ck_tile::index_t kM0 =
+          ck_tile::BlockFmhaSplitKVCombinePipelineTileSizes<
+              typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+              kN1>::kM0;
 
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVCombineTilePartitioner<kM0, kN1>;
@@ -176,7 +175,7 @@ struct grouped_forward_splitkv_mask_bias_dropout_dispatch {
               -1>;
 
           using FmhaPipelineProblem =
-              FmhaSplitKVCombinePipelineProblemTemp<kM0, kN1, FmhaTraits>;
+              FmhaSplitKVCombinePipelineProblemTemp<kN1, FmhaTraits>;
 
           using FmhaPipeline =
               ck_tile::BlockFmhaFwdSplitKVCombinePipeline<FmhaPipelineProblem>;

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_dispatch.h
@@ -13,7 +13,7 @@
 #include <ck_tile/ops/fmha.hpp>
 
 #include "ck_tiled_bool_switch.h"
-#include "ck_tiled_fmha_fwd_setting.h"
+#include "ck_tiled_fmha_fwd_splitkv_setting.h"
 #include "ck_tiled_fmha_num_kv_split_switch.h"
 #include "ck_tiled_fmha_params.h"
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h
@@ -99,7 +99,7 @@ struct grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch {
                   ODataType>;
 
               using FmhaFwdPipeline_ =
-                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                  ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
                       FmhaPipelineProblem>;
 
               using FmhaFwdEpilogue_ =
@@ -124,7 +124,7 @@ struct grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch {
                   ODataType>;
 
               using FmhaFwdPipeline_ =
-                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                  ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
                       FmhaPipelineProblem>;
 
               using FmhaFwdEpilogue_ =

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h
@@ -44,19 +44,15 @@ struct grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch {
           FmhaMask,
           FmhaFwdSplitKVTraits>;
 
-  template <
-      ck_tile::index_t kM0,
-      ck_tile::index_t kN1,
-      typename FmhaSplitKVCombineTraits>
+  template <ck_tile::index_t kN1, typename FmhaSplitKVCombineTraits>
   using FmhaSplitKVCombinePipelineProblemTemp =
       ck_tile::BlockFmhaSplitKVCombinePipelineProblem<
           typename FmhaFwdTypeConfig<ScalarType>::LSEDataType,
           typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
           typename FmhaFwdTypeConfig<ScalarType>::ODataType,
           MaxK, // headdim_v
-          kM0,
-          kN1,
           true, // kIsGroupMode
+          kN1,
           FmhaSplitKVCombineTraits>;
 
   static void Run(GroupedForwardParams& param, hipStream_t stream) {
@@ -151,8 +147,11 @@ struct grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch {
     if (param.num_kv_splits > 1) {
       using FmhaTileShape = typename FmhaFwdSplitKVSmallQShape<MaxK>::Type;
 
-      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0;
-      constexpr ck_tile::index_t kN1 = FmhaTileShape::kN1 / 2;
+      constexpr ck_tile::index_t kN1 = 32;
+      constexpr ck_tile::index_t kM0 =
+          ck_tile::BlockFmhaSplitKVCombinePipelineTileSizes<
+              typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+              kN1>::kM0;
 
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVCombineTilePartitioner<kM0, kN1>;
@@ -173,7 +172,7 @@ struct grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch {
               -1>;
 
           using FmhaPipelineProblem =
-              FmhaSplitKVCombinePipelineProblemTemp<kM0, kN1, FmhaTraits>;
+              FmhaSplitKVCombinePipelineProblemTemp<kN1, FmhaTraits>;
 
           using FmhaPipeline =
               ck_tile::BlockFmhaFwdSplitKVCombinePipeline<FmhaPipelineProblem>;

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
@@ -6,8 +6,11 @@
  */
 #pragma once
 
+#include <algorithm>
+#include "ck_tiled_fmha_fwd_splitkv_selector.h"
 #include "ck_tiled_fmha_grouped_infer_dispatch.h"
 #include "ck_tiled_fmha_grouped_infer_splitkv_dispatch.h"
+#include "ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h"
 #include "ck_tiled_fmha_seqlen_q_switch.h"
 
 template <
@@ -23,14 +26,22 @@ void run_grouped_infer_mask_bias_dropout_dispatch(
   if constexpr (!kHasDropout) {
 #ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
-      FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
-        grouped_infer_splitkv_mask_bias_dropout_dispatch<
+      if (use_splitkv_smallq(param.max_seqlen_q, std::max(param.K, param.Kv))) {
+        grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch<
             ScalarType,
             kHasMask,
             kHasBias,
-            MaxK,
-            MaxSeqlenQ>::Run(param, stream);
-      });
+            MaxK>::Run(param, stream);
+      } else {
+        FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
+          grouped_infer_splitkv_mask_bias_dropout_dispatch<
+              ScalarType,
+              kHasMask,
+              kHasBias,
+              MaxK,
+              MaxSeqlenQ>::Run(param, stream);
+        });
+      }
     } else
 #endif
       grouped_infer_mask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
@@ -7,7 +7,8 @@
 #pragma once
 
 #include <algorithm>
-#include "ck_tiled_fmha_fwd_splitkv_selector.h"
+#include "ck_tiled_fmha_fwd_setting.h"
+#include "ck_tiled_fmha_fwd_splitkv_smallq_selector.h"
 #include "ck_tiled_fmha_grouped_infer_dispatch.h"
 #include "ck_tiled_fmha_grouped_infer_splitkv_dispatch.h"
 #include "ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h"
@@ -44,18 +45,33 @@ void run_grouped_infer_mask_bias_dropout_dispatch(
       }
     } else
 #endif
-      grouped_infer_mask_bias_dropout_dispatch<
-          ScalarType,
-          kHasMask,
-          kHasBias,
-          kHasDropout,
-          MaxK>::Run(param, stream);
+    {
+      if (get_fmha_fwd_mtile(param.num_batches, param.Hq, param.max_seqlen_q) ==
+          128)
+        grouped_infer_mask_bias_dropout_dispatch<
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK,
+            128>::Run(param, stream);
+      else
+        grouped_infer_mask_bias_dropout_dispatch<
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK,
+            64>::Run(param, stream);
+    }
   } else {
+    // at present, dropout of fwd kernel requires 32x32 WarpTile
     grouped_infer_mask_bias_dropout_dispatch<
         ScalarType,
         kHasMask,
         kHasBias,
         kHasDropout,
-        MaxK>::Run(param, stream);
+        MaxK,
+        128>::Run(param, stream);
   }
 };

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer.h
@@ -25,7 +25,6 @@ void run_grouped_infer_mask_bias_dropout_dispatch(
     hipStream_t stream) {
   // currently split-kv implementation does not support dropout
   if constexpr (!kHasDropout) {
-#ifndef FMHA_FWD_SPLITKV_NOT_USED
     if (param.use_split_kv) {
       if (use_splitkv_smallq(param.max_seqlen_q, std::max(param.K, param.Kv))) {
         grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch<
@@ -43,9 +42,7 @@ void run_grouped_infer_mask_bias_dropout_dispatch(
               MaxSeqlenQ>::Run(param, stream);
         });
       }
-    } else
-#endif
-    {
+    } else {
       if (get_fmha_fwd_mtile(param.num_batches, param.Hq, param.max_seqlen_q) ==
           128)
         grouped_infer_mask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_dispatch.h
@@ -22,7 +22,8 @@ template <
     bool kHasMask,
     bool kHasBias,
     bool kHasDropout,
-    ck_tile::index_t MaxK>
+    ck_tile::index_t MaxK,
+    ck_tile::index_t MTile>
 struct grouped_infer_mask_bias_dropout_dispatch {
   template <typename FmhaTraits, typename FmhaMask>
   using FmhaPipelineProblemTemp = ck_tile::BlockFmhaPipelineProblem<
@@ -37,7 +38,7 @@ struct grouped_infer_mask_bias_dropout_dispatch {
       typename FmhaFwdTypeConfig<ScalarType>::PDataType,
       typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
       typename FmhaFwdTypeConfig<ScalarType>::ODataType,
-      FmhaFwdShape<MaxK>,
+      typename FmhaFwdShape<MaxK, MTile>::Type,
       true, // kIsGroupMode
       FmhaMask,
       FmhaTraits>;
@@ -45,7 +46,7 @@ struct grouped_infer_mask_bias_dropout_dispatch {
   static void Run(GroupedForwardParams& param, hipStream_t stream) {
     using FmhaMask = ck_tile::SimplifiedGenericAttentionMask<kHasMask>;
 
-    using FmhaShape = FmhaFwdShape<MaxK>;
+    using FmhaShape = typename FmhaFwdShape<MaxK, MTile>::Type;
     constexpr ck_tile::index_t occupancy =
         (MaxK == 64) ? 3 : ((MaxK == 256) ? 1 : 2);
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_dispatch.h
@@ -45,19 +45,15 @@ struct grouped_infer_splitkv_mask_bias_dropout_dispatch {
           FmhaMask,
           FmhaFwdSplitKVTraits>;
 
-  template <
-      ck_tile::index_t kM0,
-      ck_tile::index_t kN1,
-      typename FmhaSplitKVCombineTraits>
+  template <ck_tile::index_t kN1, typename FmhaSplitKVCombineTraits>
   using FmhaSplitKVCombinePipelineProblemTemp =
       ck_tile::BlockFmhaSplitKVCombinePipelineProblem<
           typename FmhaFwdTypeConfig<ScalarType>::LSEDataType,
           typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
           typename FmhaFwdTypeConfig<ScalarType>::ODataType,
           MaxK, // headdim_v
-          kM0,
-          kN1,
           true, // kIsGroupMode
+          kN1,
           FmhaSplitKVCombineTraits>;
 
   static void Run(GroupedForwardParams& param, hipStream_t stream) {
@@ -173,8 +169,11 @@ struct grouped_infer_splitkv_mask_bias_dropout_dispatch {
       using FmhaTileShape =
           typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type;
 
-      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0 / 2;
-      constexpr ck_tile::index_t kN1 = FmhaTileShape::kN1 / 2;
+      constexpr ck_tile::index_t kN1 = 32;
+      constexpr ck_tile::index_t kM0 =
+          ck_tile::BlockFmhaSplitKVCombinePipelineTileSizes<
+              typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+              kN1>::kM0;
 
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVCombineTilePartitioner<kM0, kN1>;
@@ -195,7 +194,7 @@ struct grouped_infer_splitkv_mask_bias_dropout_dispatch {
               -1>;
 
           using FmhaPipelineProblem =
-              FmhaSplitKVCombinePipelineProblemTemp<kM0, kN1, FmhaTraits>;
+              FmhaSplitKVCombinePipelineProblemTemp<kN1, FmhaTraits>;
 
           using FmhaPipeline =
               ck_tile::BlockFmhaFwdSplitKVCombinePipeline<FmhaPipelineProblem>;

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
@@ -13,7 +13,7 @@
 #include <ck_tile/ops/fmha.hpp>
 
 #include "ck_tiled_bool_switch.h"
-#include "ck_tiled_fmha_fwd_splitkv_setting.h"
+#include "ck_tiled_fmha_fwd_splitkv_smallq_setting.h"
 #include "ck_tiled_fmha_num_kv_split_switch.h"
 #include "ck_tiled_fmha_params.h"
 
@@ -21,9 +21,8 @@ template <
     typename ScalarType,
     bool kHasMask,
     bool kHasBias,
-    ck_tile::index_t MaxK,
-    ck_tile::index_t MaxSeqlenQ>
-struct batched_infer_splitkv_mask_bias_dropout_dispatch {
+    ck_tile::index_t MaxK>
+struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
   template <
       typename FmhaFwdSplitKVTraits,
       typename FmhaMask,
@@ -40,8 +39,8 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
           typename FmhaFwdTypeConfig<ScalarType>::PDataType,
           typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
           ODataType,
-          typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type,
-          false, // kIsGroupMode
+          typename FmhaFwdSplitKVSmallQShape<MaxK>::Type,
+          true, // kIsGroupMode
           FmhaMask,
           FmhaFwdSplitKVTraits>;
 
@@ -57,56 +56,51 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
           MaxK, // headdim_v
           kM0,
           kN1,
-          false, // kIsGroupMode
+          true, // kIsGroupMode
           FmhaSplitKVCombineTraits>;
 
-  static void Run(BatchedForwardParams& param, hipStream_t stream) {
+  static void Run(GroupedForwardParams& param, hipStream_t stream) {
     {
       using FmhaMask = ck_tile::SimplifiedGenericAttentionMask<kHasMask>;
 
-      using FmhaTileShape =
-          typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type;
+      using FmhaTileShape = typename FmhaFwdSplitKVSmallQShape<MaxK>::Type;
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVTilePartitioner<FmhaTileShape>;
+
       constexpr ck_tile::index_t occupancy = -1;
 
       constexpr auto kBiasEnum = kHasBias
           ? ck_tile::BlockAttentionBiasEnum::ELEMENTWISE_BIAS
           : ck_tile::BlockAttentionBiasEnum::NO_BIAS;
 
-      const bool pad_seqlen_q = !(param.M % FmhaTileShape::kM0 == 0);
-      const bool pad_headdim_v = !(param.Kv % FmhaTileShape::kN1 == 0);
-      const bool pad_headdim_q = !(param.K % FmhaTileShape::kSubQKHeaddim == 0);
+      constexpr bool kPadSeqLenQ = true;
+      constexpr bool kPadSeqLenK = true;
 
-      // usually headdim_q and headdim_v are same, consider them together to
-      // determine whether to do padding saving some compiling time
-      const bool pad_headdim = (pad_headdim_q || pad_headdim_v);
+      bool pad_headdim_q = !(param.K % FmhaTileShape::kSubQKHeaddim == 0);
+      bool pad_headdim_v = !(param.Kv % FmhaTileShape::kN1 == 0);
 
-      const bool has_uneven_splits =
-          !(param.N % (param.num_kv_splits * FmhaTileShape::kN0) == 0);
+      bool is_paged_kv = param.use_paged_kvcache;
 
       BOOL_SWITCH_3(
-          pad_seqlen_q,
-          kPadSeqLenQ,
-          pad_headdim,
-          kPadHeadDim,
-          has_uneven_splits,
-          kHasUnevenSplits,
+          pad_headdim_q,
+          kPadHeadDimQ,
+          pad_headdim_v,
+          kPadHeadDimV,
+          is_paged_kv,
+          kIsPagedKV,
           [&] {
-            constexpr bool kPadSeqLenK = kHasUnevenSplits ? true : false;
-
             if (param.num_kv_splits > 1) {
               using FmhaTraits = ck_tile::TileFmhaFwdSplitKVTraits<
                   kPadSeqLenQ,
                   kPadSeqLenK,
-                  kPadHeadDim, // kPadHeadDimQ,
-                  kPadHeadDim, // kPadHeadDimV,
+                  kPadHeadDimQ,
+                  kPadHeadDimV,
                   kBiasEnum,
                   false, // kHasBiasGrad place-holder
                   true, // kStoreLSE
                   false, // kDoFp8StaticQuant place-holder
-                  false, // kIsPagedKV
-                  kHasUnevenSplits,
+                  kIsPagedKV,
+                  true, // kHasUnevenSplits
                   occupancy>;
 
               using ODataType =
@@ -116,8 +110,9 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
                   FmhaMask,
                   ODataType>;
 
-              using FmhaPipeline = ck_tile::BlockFmhaFwdSplitKVPipelineQRKSVS<
-                  FmhaPipelineProblem>;
+              using FmhaPipeline =
+                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                      FmhaPipelineProblem>;
 
               using FmhaEpilogue =
                   ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -136,14 +131,14 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
               using FmhaTraits = ck_tile::TileFmhaFwdSplitKVTraits<
                   kPadSeqLenQ,
                   kPadSeqLenK,
-                  kPadHeadDim, // kPadHeadDimQ,
-                  kPadHeadDim, // kPadHeadDimV,
+                  kPadHeadDimQ,
+                  kPadHeadDimV,
                   kBiasEnum,
                   false, // kHasBiasGrad place-holder
                   false, // kStoreLSE
                   false, // kDoFp8StaticQuant place-holder
-                  false, // kIsPagedKV
-                  kHasUnevenSplits,
+                  kIsPagedKV,
+                  true, // kHasUnevenSplits
                   occupancy>;
 
               using ODataType =
@@ -153,8 +148,9 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
                   FmhaMask,
                   ODataType>;
 
-              using FmhaPipeline = ck_tile::BlockFmhaFwdSplitKVPipelineQRKSVS<
-                  FmhaPipelineProblem>;
+              using FmhaPipeline =
+                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                      FmhaPipelineProblem>;
 
               using FmhaEpilogue =
                   ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
@@ -174,62 +170,56 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
     };
 
     if (param.num_kv_splits > 1) {
-      using FmhaTileShape =
-          typename FmhaFwdSplitKVShape<MaxK, MaxSeqlenQ>::Type;
+      using FmhaTileShape = typename FmhaFwdSplitKVSmallQShape<MaxK>::Type;
 
-      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0 / 2;
+      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0;
       constexpr ck_tile::index_t kN1 = FmhaTileShape::kN1 / 2;
 
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVCombineTilePartitioner<kM0, kN1>;
       constexpr ck_tile::index_t occupancy = -1;
 
-      const bool pad_seqlen_q = !(param.M % kM0 == 0);
+      constexpr bool kPadSeqLenQ = true;
+
       const bool pad_headdim_v = !(param.Kv % kN1 == 0);
 
-      BOOL_SWITCH_2(
-          pad_seqlen_q, kPadSeqLenQ, pad_headdim_v, kPadHeadDimV, [&] {
-            FMHA_FWD_NUM_KV_SPLITS_SWITCH(
-                param.num_kv_splits, kLogMaxSplits, [&] {
-                  using FmhaTraits = ck_tile::TileFmhaFwdSplitKVCombineTraits<
-                      kPadSeqLenQ,
-                      kPadHeadDimV,
-                      false, // kStoreLSE
-                      false, // kDoFp8StaticQuant place-holder
-                      kLogMaxSplits,
-                      -1>;
+      BOOL_SWITCH(pad_headdim_v, kPadHeadDimV, [&] {
+        FMHA_FWD_NUM_KV_SPLITS_SWITCH(param.num_kv_splits, kLogMaxSplits, [&] {
+          using FmhaTraits = ck_tile::TileFmhaFwdSplitKVCombineTraits<
+              kPadSeqLenQ,
+              kPadHeadDimV,
+              false, // kStoreLSE
+              false, // kDoFp8StaticQuant place-holder
+              kLogMaxSplits,
+              -1>;
 
-                  using FmhaPipelineProblem =
-                      FmhaSplitKVCombinePipelineProblemTemp<
-                          kM0,
-                          kN1,
-                          FmhaTraits>;
+          using FmhaPipelineProblem =
+              FmhaSplitKVCombinePipelineProblemTemp<kM0, kN1, FmhaTraits>;
 
-                  using FmhaPipeline =
-                      ck_tile::BlockFmhaFwdSplitKVCombinePipeline<
-                          FmhaPipelineProblem>;
+          using FmhaPipeline =
+              ck_tile::BlockFmhaFwdSplitKVCombinePipeline<FmhaPipelineProblem>;
 
-                  using FmhaEpilogue = ck_tile::Default2DEpilogue<
-                      ck_tile::Default2DEpilogueProblem<
-                          typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
-                          typename FmhaFwdTypeConfig<ScalarType>::ODataType,
-                          kPadSeqLenQ,
-                          kPadHeadDimV>>;
+          using FmhaEpilogue =
+              ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
+                  typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+                  typename FmhaFwdTypeConfig<ScalarType>::ODataType,
+                  kPadSeqLenQ,
+                  kPadHeadDimV>>;
 
-                  using FmhaKernel = ck_tile::FmhaFwdSplitKVCombineKernel<
-                      FmhaTilePartitioner,
-                      FmhaPipeline,
-                      FmhaEpilogue>;
+          using FmhaKernel = ck_tile::FmhaFwdSplitKVCombineKernel<
+              FmhaTilePartitioner,
+              FmhaPipeline,
+              FmhaEpilogue>;
 
-                  RunWithSplitKVCombineKernel<FmhaKernel>(param, stream);
-                });
-          });
+          RunWithSplitKVCombineKernel<FmhaKernel>(param, stream);
+        });
+      });
     };
   };
 
   template <typename FmhaFwdSplitKVKernel>
   static void RunWithFwdSplitKVKernel(
-      BatchedForwardParams& param,
+      GroupedForwardParams& param,
       hipStream_t stream) {
     const auto kargs = [&] {
       if (param.num_kv_splits > 1)
@@ -240,42 +230,39 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
             param.attn_bias_ptr,
             param.logsumexp_acc_ptr,
             param.out_acc_ptr,
-            param.B, // batch
-            param.M, // seqlen_q
-            param.N, // seqlen_k
-            nullptr, // seqlen_k_ptr, not used
+            param.num_batches,
+            param.seqstart_q_dev_ptr,
+            param.seqstart_k_dev_ptr,
+            param.seqlen_k_dev_ptr,
             param.K, // hdim_q
             param.Kv, // hdim_v
             param.Hq, // nhead_q
             param.Hq / param.Hkv, // nhead_ratio_qk
             param.num_kv_splits, // num_splits
-            nullptr, // block_table_ptr, not used
-            0, // batch_stride_block_table, not used
-            0, // page_table_size, not used
-            nullptr, // cache_batch_idx, not used
+            param.use_paged_kvcache ? param.block_table_ptr : nullptr,
+            param.use_paged_kvcache ? param.batch_stride_block_table : 0,
+            param.use_paged_kvcache ? param.page_block_size : 0,
+            param.use_paged_kvcache ? param.is_gappy : false,
             param.scale,
             1.0f, // scale_p
-            param.q_strides[1], // q, k, v, bias, out_acc tensor seq-dim
+            param.q_strides[0], // q, k, v, bias, out_acc tensor seq-dim
                                 // stride
-            param.k_strides[1],
-            param.v_strides[1],
-            param.attn_bias_strides[2],
-            param.out_acc_strides[2],
-            param.q_strides[2], // q, k, v, bias, lse_acc, out_acc tensor
-                                // head-dim stride
-            param.k_strides[2],
-            param.v_strides[2],
-            param.attn_bias_strides[1],
-            param.lse_acc_strides[2],
-            param.out_acc_strides[3],
-            param.q_strides[0], // q, k, v, bias, lse_acc, out_acc tensor
-                                // batch-dim stride
             param.k_strides[0],
             param.v_strides[0],
-            param.attn_bias_strides[0],
-            param.lse_acc_strides[1],
+            param.attn_bias_strides[2],
             param.out_acc_strides[1],
-            param.lse_acc_strides[0], // split_stride_lse_acc
+            param.q_strides[1], // q, k, v, bias, lse_acc, out_acc tensor
+                                // head-dim stride
+            param.k_strides[1],
+            param.v_strides[1],
+            param.attn_bias_strides[1],
+            param.lse_acc_strides[1],
+            param.out_acc_strides[2],
+            param.use_paged_kvcache ? param.k_strides[0] * param.page_block_size
+                                    : 0, // batch_stride_k
+            param.use_paged_kvcache ? param.v_strides[0] * param.page_block_size
+                                    : 0, // batch_stride_v
+            param.lse_acc_strides[0], // split_stride_l
             param.out_acc_strides[0], // split_stride_out_acc
             (param.window_size > 0) ? param.window_size - 1
                                     : -1, // window_left_size
@@ -287,42 +274,40 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
             param.k_ptr,
             param.v_ptr,
             param.attn_bias_ptr,
-            nullptr, // lse_ptr
+            nullptr, // lse_ptr,
             param.out_ptr,
-            param.B, // batch
-            param.M, // seqlen_q
-            param.N, // seqlen_k
-            nullptr, // seqlen_k_ptr, not used
+            param.num_batches,
+            param.seqstart_q_dev_ptr,
+            param.seqstart_k_dev_ptr,
+            param.seqlen_k_dev_ptr,
             param.K, // hdim_q
             param.Kv, // hdim_v
             param.Hq, // nhead_q
             param.Hq / param.Hkv, // nhead_ratio_qk
             param.num_kv_splits, // num_splits
-            nullptr, // block_table_ptr, not used
-            0, // batch_stride_block_table, not used
-            0, // page_table_size, not used
-            nullptr, // cache_batch_idx, not used
+            param.use_paged_kvcache ? param.block_table_ptr : nullptr,
+            param.use_paged_kvcache ? param.batch_stride_block_table : 0,
+            param.use_paged_kvcache ? param.page_block_size : 0,
+            param.use_paged_kvcache ? param.is_gappy : false,
             param.scale,
             1.0f, // scale_p
-            param.q_strides[1], // q, k, v, bias, out tensor seq-dim stride
-            param.k_strides[1],
-            param.v_strides[1],
-            param.attn_bias_strides[2],
-            param.out_strides[1],
-            param.q_strides[2], // q, k, v, bias, lse, out tensor head-dim
+            param.q_strides[0], // q, k, v, bias, out tensor seq-dim
                                 // stride
-            param.k_strides[2],
-            param.v_strides[2],
-            param.attn_bias_strides[1],
-            0, // nhead_stride_lse
-            param.out_strides[2],
-            param.q_strides[0], // q, k, v, bias, lse, out tensor
-                                // batch-dim stride
             param.k_strides[0],
             param.v_strides[0],
-            param.attn_bias_strides[0],
-            0, // batch_stride_lse
+            param.attn_bias_strides[2],
             param.out_strides[0],
+            param.q_strides[1], // q, k, v, bias, lse, out tensor
+                                // head-dim stride
+            param.k_strides[1],
+            param.v_strides[1],
+            param.attn_bias_strides[1],
+            0, // nhead_stride_lse
+            param.out_strides[1],
+            param.use_paged_kvcache ? param.k_strides[0] * param.page_block_size
+                                    : 0, // batch_stride_k
+            param.use_paged_kvcache ? param.v_strides[0] * param.page_block_size
+                                    : 0, // batch_stride_v
             0, // split_stride_lse_acc
             0, // split_stride_out_acc
             (param.window_size > 0) ? param.window_size - 1
@@ -332,7 +317,11 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
     }();
 
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
-        param.B, param.Hq, param.M, param.Kv, param.num_kv_splits);
+        param.num_batches,
+        param.Hq,
+        param.max_seqlen_q,
+        param.Kv,
+        param.num_kv_splits);
     constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 
@@ -344,7 +333,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
 
   template <typename FmhaSplitKVCombineKernel>
   static void RunWithSplitKVCombineKernel(
-      BatchedForwardParams& param,
+      GroupedForwardParams& param,
       hipStream_t stream) {
     const auto kargs = [&] {
       return FmhaSplitKVCombineKernel::MakeKargs(
@@ -352,27 +341,23 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
           param.out_acc_ptr,
           nullptr, // lse_ptr, not used
           param.out_ptr,
-          param.B, // batches
-          param.M, // seqlen_q
+          param.num_batches,
+          param.seqstart_q_dev_ptr,
           param.Kv,
           param.num_kv_splits,
           1.0f,
-          param.out_acc_strides[2], // row_stride_o_acc
-          param.out_strides[1], // row_stride_o
-          param.lse_acc_strides[2], // head_stride_lse_acc
-          param.out_acc_strides[3], // head_stride_o_acc
-          0, // head_stride_lse, // not used
-          param.out_strides[2], // head_stride_o
-          param.lse_acc_strides[1], // batch_stride_lse_acc
-          param.out_acc_strides[1], // batch_stride_o_acc
-          0, // batch_stride_lse, not used
-          param.out_strides[0], // batch_stride_o
-          param.lse_acc_strides[0], // split_stride_lse_acc
-          param.out_acc_strides[0]); // split_stride_out_acc
+          param.out_acc_strides[1], // row_stride_o_acc,
+          param.out_strides[0], // row_stride_o,
+          param.lse_acc_strides[1], // nhead_stride_lse_acc
+          param.out_acc_strides[2], // nhead_stride_o_acc,
+          0, // nhead_stride_lse,
+          param.out_strides[1], // nhead_stride_o,
+          param.lse_acc_strides[0], // split_stride_lse_acc,
+          param.out_acc_strides[0]); // split_stride_o_acc
     }();
 
     dim3 kGridSize = FmhaSplitKVCombineKernel::GridSize(
-        param.B, param.Hq, param.M, param.Kv);
+        param.num_batches, param.Hq, param.max_seqlen_q, param.Kv);
     constexpr dim3 kBlockSize = FmhaSplitKVCombineKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu =
         FmhaSplitKVCombineKernel::kBlockPerCu;

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
@@ -107,7 +107,7 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
                   ODataType>;
 
               using FmhaPipeline =
-                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                  ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
                       FmhaPipelineProblem>;
 
               using FmhaEpilogue =
@@ -145,7 +145,7 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
                   ODataType>;
 
               using FmhaPipeline =
-                  ck_tile::BlockFmhaFwdSplitKVSmallQPipelineQRKSVS<
+                  ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
                       FmhaPipelineProblem>;
 
               using FmhaEpilogue =

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
@@ -44,19 +44,15 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
           FmhaMask,
           FmhaFwdSplitKVTraits>;
 
-  template <
-      ck_tile::index_t kM0,
-      ck_tile::index_t kN1,
-      typename FmhaSplitKVCombineTraits>
+  template <ck_tile::index_t kN1, typename FmhaSplitKVCombineTraits>
   using FmhaSplitKVCombinePipelineProblemTemp =
       ck_tile::BlockFmhaSplitKVCombinePipelineProblem<
           typename FmhaFwdTypeConfig<ScalarType>::LSEDataType,
           typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
           typename FmhaFwdTypeConfig<ScalarType>::ODataType,
           MaxK, // headdim_v
-          kM0,
-          kN1,
           true, // kIsGroupMode
+          kN1,
           FmhaSplitKVCombineTraits>;
 
   static void Run(GroupedForwardParams& param, hipStream_t stream) {
@@ -172,8 +168,11 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
     if (param.num_kv_splits > 1) {
       using FmhaTileShape = typename FmhaFwdSplitKVSmallQShape<MaxK>::Type;
 
-      constexpr ck_tile::index_t kM0 = FmhaTileShape::kM0;
-      constexpr ck_tile::index_t kN1 = FmhaTileShape::kN1 / 2;
+      constexpr ck_tile::index_t kN1 = 32;
+      constexpr ck_tile::index_t kM0 =
+          ck_tile::BlockFmhaSplitKVCombinePipelineTileSizes<
+              typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+              kN1>::kM0;
 
       using FmhaTilePartitioner =
           ck_tile::FmhaFwdSplitKVCombineTilePartitioner<kM0, kN1>;
@@ -194,7 +193,7 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
               -1>;
 
           using FmhaPipelineProblem =
-              FmhaSplitKVCombinePipelineProblemTemp<kM0, kN1, FmhaTraits>;
+              FmhaSplitKVCombinePipelineProblemTemp<kN1, FmhaTraits>;
 
           using FmhaPipeline =
               ck_tile::BlockFmhaFwdSplitKVCombinePipeline<FmhaPipelineProblem>;

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_num_kv_split_switch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_num_kv_split_switch.h
@@ -11,14 +11,14 @@
 
 #define FMHA_FWD_NUM_KV_SPLITS_SWITCH(NUM_SPLITS, CONST_NAME, ...) \
   [&] {                                                            \
-    if (NUM_SPLITS <= 8) {                                         \
+    if (NUM_SPLITS <= 4) {                                         \
+      constexpr ck_tile::index_t CONST_NAME = 2;                   \
+      __VA_ARGS__();                                               \
+    } else if (NUM_SPLITS <= 8) {                                  \
       constexpr ck_tile::index_t CONST_NAME = 3;                   \
       __VA_ARGS__();                                               \
     } else if (NUM_SPLITS <= 16) {                                 \
       constexpr ck_tile::index_t CONST_NAME = 4;                   \
-      __VA_ARGS__();                                               \
-    } else if (NUM_SPLITS <= 32) {                                 \
-      constexpr ck_tile::index_t CONST_NAME = 5;                   \
       __VA_ARGS__();                                               \
     } else {                                                       \
       throw std::runtime_error("num-splits not supported!");       \

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_num_kv_split_switch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_num_kv_split_switch.h
@@ -11,10 +11,7 @@
 
 #define FMHA_FWD_NUM_KV_SPLITS_SWITCH(NUM_SPLITS, CONST_NAME, ...) \
   [&] {                                                            \
-    if (NUM_SPLITS <= 4) {                                         \
-      constexpr ck_tile::index_t CONST_NAME = 2;                   \
-      __VA_ARGS__();                                               \
-    } else if (NUM_SPLITS <= 8) {                                  \
+    if (NUM_SPLITS <= 8) {                                         \
       constexpr ck_tile::index_t CONST_NAME = 3;                   \
       __VA_ARGS__();                                               \
     } else if (NUM_SPLITS <= 16) {                                 \

--- a/xformers/ops/fmha/ck.py
+++ b/xformers/ops/fmha/ck.py
@@ -53,7 +53,13 @@ def _get_seqlen_info(
     attn_bias = inp.attn_bias
     if isinstance(
         attn_bias,
-        (BlockDiagonalMask, BlockDiagonalPaddedKeysMask, BlockDiagonalGappyKeysMask, PagedBlockDiagonalPaddedKeysMask, PagedBlockDiagonalGappyKeysMask)
+        (
+            BlockDiagonalMask,
+            BlockDiagonalPaddedKeysMask,
+            BlockDiagonalGappyKeysMask,
+            PagedBlockDiagonalPaddedKeysMask,
+            PagedBlockDiagonalGappyKeysMask,
+        ),
     ):
         attn_bias.k_seqinfo.to(inp.query.device)
         attn_bias.q_seqinfo.to(inp.query.device)
@@ -205,62 +211,30 @@ class FwOp(AttentionFwOpBase):
     ) -> Tuple[torch.Tensor, Optional[Context]]:
         if type(inp.attn_bias) not in FwOp.SUPPORTED_ATTN_BIAS_TYPES:
             raise NotImplementedError("Unsupported attn_bias type")
-        if inp.query.ndim in [3, 4]:
+        if inp.query.ndim in [1, 2, 3]:
+            raise NotImplementedError("Unsupported number of dimensions")
+        if inp.query.ndim in [4]:
             return cls.apply_bmhk(inp, needs_gradient=needs_gradient)
         assert inp.query.ndim == 5, f"query has shape {inp.query.shape}"
         ctx: Optional[Context] = None
-        # XXX: Hackfix for BMGHK with H=1
-        # In that case we don't want to run G different streams because it adds
-        # some overhead
-        if inp.query.ndim == 5 and inp.query.shape[3] == 1:
-            slice_op = partial(torch.squeeze, dim=3)
-            inp = replace(
-                inp,
-                query=slice_op(inp.query),
-                key=slice_op(inp.key),
-                value=slice_op(inp.value),
-                attn_bias=_attn_bias_apply(
-                    inp.attn_bias, partial(torch.squeeze, dim=2)
-                ),
-            )
-            out, ctx = cls.apply_bmhk(inp, needs_gradient=needs_gradient)
-            out = out.unsqueeze(3)
-            if ctx is not None:
-                ctx = replace(ctx, lse=ctx.lse.unsqueeze(1), out=out)
-            return out, ctx
 
-        # Workaround until this is properly implemented in C++
-        # run each head group in a different stream
-        n_groups = inp.key.shape[2]
-        main_stream = torch.cuda.current_stream()
-        streams = [main_stream] + [
-            torch.cuda.Stream(device=inp.query.device) for _ in range(n_groups - 1)
-        ]
-        outs = []
-        for group, stream in enumerate(streams):
-            stream.wait_stream(main_stream)
-            with torch.cuda.stream(stream):
-                query = inp.query[:, :, group]
-                key = inp.key[:, :, group]
-                value = inp.value[:, :, group]
-                bias = _attn_bias_apply(
-                    inp.attn_bias, partial(torch.select, dim=1, index=group)
-                )
-                outs.append(
-                    cls.apply_bmhk(
-                        replace(inp, query=query, key=key, value=value, attn_bias=bias),
-                        needs_gradient=needs_gradient,
-                    )
-                )
-        for s in streams[1:]:
-            main_stream.wait_stream(s)
-        out = torch.stack([o[0] for o in outs], dim=2)
-        if needs_gradient:
-            ctx = Context(
-                out=out,
-                lse=torch.stack([o[1].lse for o in outs], dim=1),  # type: ignore
-                op_bw=outs[0][1].op_bw,  # type: ignore
-            )
+        [B, q_len, G, Hq, K] = inp.query.shape
+        [_, kv_len, _, Hkv, Kv] = inp.key.shape
+        attn_bias_replace = inp.attn_bias
+        if isinstance(inp.attn_bias, torch.Tensor) and inp.attn_bias.ndim != 0:
+            attn_bias_replace = torch.reshape(inp.attn_bias, (B, G * Hq, M, N))
+        inp = replace(
+            inp,
+            query=torch.reshape(inp.query, (B, q_len, G * Hq, K)),
+            key=torch.reshape(inp.key, (B, kv_len, G * Hkv, K)),
+            value=torch.reshape(inp.value, (B, kv_len, G * Hkv, Kv)),
+            attn_bias=attn_bias_replace,
+        )
+        out, ctx = cls.apply_bmhk(inp, needs_gradient=needs_gradient)
+        out = torch.reshape(out, (B, q_len, G, Hq, Kv))
+        if ctx is not None:
+            lse = torch.reshape(ctx.lse, (B, G, Hq, q_len))
+            ctx = replace(ctx, lse=lse, out=out)
         return out, ctx
 
     @classmethod


### PR DESCRIPTION
1. The SplitkvNWarpSShuffling pipeline provides good performance for small seqlen-q sizes

2. Refined the pipeline selecting method to map suitable situations to different kernel/pipelines

