### PR TITLE
mqa_decoder improvement 

### DIFF
--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_dispatch.h
@@ -100,6 +100,7 @@ struct batched_forward_splitkv_mask_bias_dropout_dispatch {
                 false, // kDoFp8StaticQuant place-holder
                 false, // kIsPagedKV
                 kHasUnevenSplits,
+                false, // kMergeNumHeadGroupsSeqLenQ
                 occupancy>;
 
             if (param.num_kv_splits > 1) {
@@ -305,7 +306,7 @@ struct batched_forward_splitkv_mask_bias_dropout_dispatch {
     }();
 
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
-        param.B, param.Hq, param.M, param.Kv, param.num_kv_splits);
+        param.B, param.Hq, param.Hkv, param.M, param.Kv, param.num_kv_splits);
     constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
@@ -98,6 +98,7 @@ struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
                 false, // kDoFp8StaticQuant place-holder
                 false, // kIsPagedKV
                 kHasUnevenSplits,
+                false, // kMergeNumHeadGroupsSeqLenQ
                 occupancy>;
 
             if (param.num_kv_splits > 1) {
@@ -304,7 +305,7 @@ struct batched_forward_splitkv_smallq_mask_bias_dropout_dispatch {
     }();
 
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
-        param.B, param.Hq, param.M, param.Kv, param.num_kv_splits);
+        param.B, param.Hq, param.Hkv, param.M, param.Kv, param.num_kv_splits);
     constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_infer_splitkv_dispatch.h
@@ -101,6 +101,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
                   false, // kDoFp8StaticQuant place-holder
                   false, // kIsPagedKV
                   kHasUnevenSplits,
+                  false, // kMergeNumHeadGroupsSeqLenQ
                   occupancy>;
 
               using ODataType =
@@ -136,6 +137,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
                   false, // kDoFp8StaticQuant place-holder
                   false, // kIsPagedKV
                   kHasUnevenSplits,
+                  false, // kMergeNumHeadGroupsSeqLenQ
                   occupancy>;
 
               using ODataType =
@@ -318,7 +320,7 @@ struct batched_infer_splitkv_mask_bias_dropout_dispatch {
     }();
 
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
-        param.B, param.Hq, param.M, param.Kv, param.num_kv_splits);
+        param.B, param.Hq, param.Hkv, param.M, param.Kv, param.num_kv_splits);
     constexpr dim3 kBlockSize = FmhaFwdSplitKVKernel::BlockSize();
     constexpr ck_tile::index_t kBlockPerCu = FmhaFwdSplitKVKernel::kBlockPerCu;
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_dispatch.h
@@ -88,6 +88,7 @@ struct grouped_forward_splitkv_mask_bias_dropout_dispatch {
                 false, // kDoFp8StaticQuant place-holder
                 false, // kIsPagedKV
                 true, // kHasUnevenSplits
+                false, // kMergeNumHeadGroupsSeqLenQ
                 occupancy>;
 
             if (param.num_kv_splits > 1) {
@@ -285,6 +286,7 @@ struct grouped_forward_splitkv_mask_bias_dropout_dispatch {
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
         param.num_batches,
         param.Hq,
+        param.Hkv,
         param.max_seqlen_q,
         param.Kv,
         param.num_kv_splits);

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h
@@ -86,6 +86,7 @@ struct grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch {
                 false, // kDoFp8StaticQuant place-holder
                 false, // kIsPagedKV
                 true, // kHasUnevenSplits
+                false, // kMergeNumHeadGroupsSeqLenQ
                 occupancy>;
 
             if (param.num_kv_splits > 1) {
@@ -282,6 +283,7 @@ struct grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch {
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
         param.num_batches,
         param.Hq,
+        param.Hkv,
         param.max_seqlen_q,
         param.Kv,
         param.num_kv_splits);

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_dispatch.h
@@ -97,6 +97,7 @@ struct grouped_infer_splitkv_mask_bias_dropout_dispatch {
                   false, // kDoFp8StaticQuant place-holder
                   kIsPagedKV,
                   true, // kHasUnevenSplits
+                  false, // kMergeNumHeadGroupsSeqLenQ
                   occupancy>;
 
               using ODataType =
@@ -132,6 +133,7 @@ struct grouped_infer_splitkv_mask_bias_dropout_dispatch {
                   false, // kDoFp8StaticQuant place-holder
                   kIsPagedKV,
                   true, // kHasUnevenSplits
+                  false, // kMergeNumHeadGroupsSeqLenQ
                   occupancy>;
 
               using ODataType =
@@ -309,6 +311,7 @@ struct grouped_infer_splitkv_mask_bias_dropout_dispatch {
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
         param.num_batches,
         param.Hq,
+        param.Hkv,
         param.max_seqlen_q,
         param.Kv,
         param.num_kv_splits);

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_infer_splitkv_smallq_dispatch.h
@@ -75,88 +75,183 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
 
       bool is_paged_kv = param.use_paged_kvcache;
 
-      BOOL_SWITCH_3(
-          pad_headdim_q,
-          kPadHeadDimQ,
-          pad_headdim_v,
-          kPadHeadDimV,
-          is_paged_kv,
-          kIsPagedKV,
-          [&] {
-            if (param.num_kv_splits > 1) {
-              using FmhaTraits = ck_tile::TileFmhaFwdSplitKVTraits<
-                  kPadSeqLenQ,
-                  kPadSeqLenK,
-                  kPadHeadDimQ,
-                  kPadHeadDimV,
-                  kBiasEnum,
-                  false, // kHasBiasGrad place-holder
-                  true, // kStoreLSE
-                  false, // kDoFp8StaticQuant place-holder
-                  kIsPagedKV,
-                  true, // kHasUnevenSplits
-                  occupancy>;
+      // indicates to the splitkv kernel whether should it merge Hq/Hkv with
+      // seqlen_q
+      const bool merge_nhead_groups_seqlen_q =
+          ((param.max_seqlen_q == 1) && (param.Hq > param.Hkv) && !kHasBias);
 
-              using ODataType =
-                  typename FmhaFwdTypeConfig<ScalarType>::OaccDataType;
-              using FmhaPipelineProblem = FmhaFwdSplitKVPipelineProblemTemp<
-                  FmhaTraits,
-                  FmhaMask,
-                  ODataType>;
+      if (merge_nhead_groups_seqlen_q) {
+        using FmhaMaskNone = ck_tile::SimplifiedGenericAttentionMask<false>;
+        BOOL_SWITCH_3(
+            pad_headdim_q,
+            kPadHeadDimQ,
+            pad_headdim_v,
+            kPadHeadDimV,
+            is_paged_kv,
+            kIsPagedKV,
+            [&] {
+              if (param.num_kv_splits > 1) {
+                using FmhaTraits = ck_tile::TileFmhaFwdSplitKVTraits<
+                    kPadSeqLenQ,
+                    kPadSeqLenK,
+                    kPadHeadDimQ,
+                    kPadHeadDimV,
+                    ck_tile::BlockAttentionBiasEnum::NO_BIAS,
+                    false, // kHasBiasGrad place-holder
+                    true, // kStoreLSE
+                    false, // kDoFp8StaticQuant place-holder
+                    kIsPagedKV,
+                    true, // kHasUnevenSplits
+                    true, // kMergeNumHeadGroupsSeqLenQ
+                    occupancy>;
 
-              using FmhaPipeline =
-                  ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
-                      FmhaPipelineProblem>;
+                using ODataType =
+                    typename FmhaFwdTypeConfig<ScalarType>::OaccDataType;
+                using FmhaPipelineProblem = FmhaFwdSplitKVPipelineProblemTemp<
+                    FmhaTraits,
+                    FmhaMaskNone,
+                    ODataType>;
 
-              using FmhaEpilogue =
-                  ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
-                      typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
-                      ODataType,
-                      false,
-                      false>>;
+                using FmhaPipeline =
+                    ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
+                        FmhaPipelineProblem>;
 
-              using FmhaKernel =
-                  ck_tile::FmhaFwdSplitKVKernel<FmhaPipeline, FmhaEpilogue>;
+                using FmhaEpilogue = ck_tile::Default2DEpilogue<
+                    ck_tile::Default2DEpilogueProblem<
+                        typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+                        ODataType,
+                        false,
+                        false>>;
 
-              RunWithFwdSplitKVKernel<FmhaKernel>(param, stream);
-            } else {
-              using FmhaTraits = ck_tile::TileFmhaFwdSplitKVTraits<
-                  kPadSeqLenQ,
-                  kPadSeqLenK,
-                  kPadHeadDimQ,
-                  kPadHeadDimV,
-                  kBiasEnum,
-                  false, // kHasBiasGrad place-holder
-                  false, // kStoreLSE
-                  false, // kDoFp8StaticQuant place-holder
-                  kIsPagedKV,
-                  true, // kHasUnevenSplits
-                  occupancy>;
+                using FmhaKernel =
+                    ck_tile::FmhaFwdSplitKVKernel<FmhaPipeline, FmhaEpilogue>;
 
-              using ODataType =
-                  typename FmhaFwdTypeConfig<ScalarType>::ODataType;
-              using FmhaPipelineProblem = FmhaFwdSplitKVPipelineProblemTemp<
-                  FmhaTraits,
-                  FmhaMask,
-                  ODataType>;
+                RunWithFwdSplitKVKernel<FmhaKernel>(param, stream);
+              } else {
+                using FmhaTraits = ck_tile::TileFmhaFwdSplitKVTraits<
+                    kPadSeqLenQ,
+                    kPadSeqLenK,
+                    kPadHeadDimQ,
+                    kPadHeadDimV,
+                    ck_tile::BlockAttentionBiasEnum::NO_BIAS,
+                    false, // kHasBiasGrad place-holder
+                    false, // kStoreLSE
+                    false, // kDoFp8StaticQuant place-holder
+                    kIsPagedKV,
+                    true, // kHasUnevenSplits
+                    true, // kMergeNumHeadGroupsSeqLenQ
+                    occupancy>;
 
-              using FmhaPipeline =
-                  ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
-                      FmhaPipelineProblem>;
+                using ODataType =
+                    typename FmhaFwdTypeConfig<ScalarType>::ODataType;
+                using FmhaPipelineProblem = FmhaFwdSplitKVPipelineProblemTemp<
+                    FmhaTraits,
+                    FmhaMaskNone,
+                    ODataType>;
 
-              using FmhaEpilogue =
-                  ck_tile::Default2DEpilogue<ck_tile::Default2DEpilogueProblem<
-                      typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
-                      ODataType,
-                      false,
-                      false>>;
+                using FmhaPipeline =
+                    ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
+                        FmhaPipelineProblem>;
 
-              using FmhaKernel =
-                  ck_tile::FmhaFwdSplitKVKernel<FmhaPipeline, FmhaEpilogue>;
+                using FmhaEpilogue = ck_tile::Default2DEpilogue<
+                    ck_tile::Default2DEpilogueProblem<
+                        typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+                        ODataType,
+                        false,
+                        false>>;
 
-              RunWithFwdSplitKVKernel<FmhaKernel>(param, stream);
-            }
-          });
+                using FmhaKernel =
+                    ck_tile::FmhaFwdSplitKVKernel<FmhaPipeline, FmhaEpilogue>;
+
+                RunWithFwdSplitKVKernel<FmhaKernel>(param, stream);
+              }
+            });
+      } else {
+        BOOL_SWITCH_3(
+            pad_headdim_q,
+            kPadHeadDimQ,
+            pad_headdim_v,
+            kPadHeadDimV,
+            is_paged_kv,
+            kIsPagedKV,
+            [&] {
+              if (param.num_kv_splits > 1) {
+                using FmhaTraits = ck_tile::TileFmhaFwdSplitKVTraits<
+                    kPadSeqLenQ,
+                    kPadSeqLenK,
+                    kPadHeadDimQ,
+                    kPadHeadDimV,
+                    kBiasEnum,
+                    false, // kHasBiasGrad place-holder
+                    true, // kStoreLSE
+                    false, // kDoFp8StaticQuant place-holder
+                    kIsPagedKV,
+                    true, // kHasUnevenSplits
+                    false, // kMergeNumHeadGroupsSeqLenQ
+                    occupancy>;
+
+                using ODataType =
+                    typename FmhaFwdTypeConfig<ScalarType>::OaccDataType;
+                using FmhaPipelineProblem = FmhaFwdSplitKVPipelineProblemTemp<
+                    FmhaTraits,
+                    FmhaMask,
+                    ODataType>;
+
+                using FmhaPipeline =
+                    ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
+                        FmhaPipelineProblem>;
+
+                using FmhaEpilogue = ck_tile::Default2DEpilogue<
+                    ck_tile::Default2DEpilogueProblem<
+                        typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+                        ODataType,
+                        false,
+                        false>>;
+
+                using FmhaKernel =
+                    ck_tile::FmhaFwdSplitKVKernel<FmhaPipeline, FmhaEpilogue>;
+
+                RunWithFwdSplitKVKernel<FmhaKernel>(param, stream);
+              } else {
+                using FmhaTraits = ck_tile::TileFmhaFwdSplitKVTraits<
+                    kPadSeqLenQ,
+                    kPadSeqLenK,
+                    kPadHeadDimQ,
+                    kPadHeadDimV,
+                    kBiasEnum,
+                    false, // kHasBiasGrad place-holder
+                    false, // kStoreLSE
+                    false, // kDoFp8StaticQuant place-holder
+                    kIsPagedKV,
+                    true, // kHasUnevenSplits
+                    false, // kMergeNumHeadGroupsSeqLenQ
+                    occupancy>;
+
+                using ODataType =
+                    typename FmhaFwdTypeConfig<ScalarType>::ODataType;
+                using FmhaPipelineProblem = FmhaFwdSplitKVPipelineProblemTemp<
+                    FmhaTraits,
+                    FmhaMask,
+                    ODataType>;
+
+                using FmhaPipeline =
+                    ck_tile::BlockFmhaFwdSplitKVPipelineNWarpSShuffleQRKSVS<
+                        FmhaPipelineProblem>;
+
+                using FmhaEpilogue = ck_tile::Default2DEpilogue<
+                    ck_tile::Default2DEpilogueProblem<
+                        typename FmhaFwdTypeConfig<ScalarType>::OaccDataType,
+                        ODataType,
+                        false,
+                        false>>;
+
+                using FmhaKernel =
+                    ck_tile::FmhaFwdSplitKVKernel<FmhaPipeline, FmhaEpilogue>;
+
+                RunWithFwdSplitKVKernel<FmhaKernel>(param, stream);
+              }
+            });
+      };
     };
 
     if (param.num_kv_splits > 1) {
@@ -308,6 +403,7 @@ struct grouped_infer_splitkv_smallq_mask_bias_dropout_dispatch {
     dim3 kGridSize = FmhaFwdSplitKVKernel::GridSize(
         param.num_batches,
         param.Hq,
+        param.Hkv,
         param.max_seqlen_q,
         param.Kv,
         param.num_kv_splits);


### PR DESCRIPTION
This PR improves the fmha-fwd for decoder cases where the `nhead_q` is bigger than `nhead_kv` (mqa or gqa).  The corresponding implementation in fmha splitkv kernel is by following PR.  The implementation in the kernel achieves the improvement by merging the `nhead_q/nhead_kv` into `seqlen_q` for tiling, which reduces the wasting by `MFMA_16x16x16`. 

[ck pr 1789](https://github.com/ROCm/composable_kernel/pull/1789)