### PR TITLE
update to rocm 6.3 wheels

### DIFF
--- a/.github/actions/setup-build-cuda/action.yml
+++ b/.github/actions/setup-build-cuda/action.yml
@@ -26,12 +26,14 @@ runs:
         TORCH_CUDA_DEFAULT = "121"  # pytorch 2.4.1
         # https://github.com/Jimver/cuda-toolkit/blob/master/src/links/linux-links.ts
         full_version, install_script = {
+          "126": ("12.6.3", "https://developer.download.nvidia.com/compute/cuda/12.6.3/local_installers/cuda_12.6.3_560.35.05_linux.run"),
           "124": ("12.4.1", "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run"),
           "121": ("12.1.0", "https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux.run"),
           "118": ("11.8.0", "https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_520.61.05_linux.run"),
           "6.0": ("6.0.2", "https://repo.radeon.com/amdgpu-install/6.0.2/rhel/8.9/amdgpu-install-6.0.60002-1.el8.noarch.rpm"),
           "6.1": ("6.1.2", "https://repo.radeon.com/amdgpu-install/6.1.3/rhel/8.9/amdgpu-install-6.1.60103-1.el8.noarch.rpm"),
-          "6.2": ("6.2.3", "https://repo.radeon.com/amdgpu-install/6.2.3/rhel/8.9/amdgpu-install-6.2.60203-1.el8.noarch.rpm"),
+          "6.2": ("6.2.4", "https://repo.radeon.com/amdgpu-install/6.2.4/rhel/8.9/amdgpu-install-6.2.60204-1.el8.noarch.rpm"),
+          "6.3": ("6.3.1", "https://repo.radeon.com/amdgpu-install/6.3.1/rhel/8.9/amdgpu-install-6.3.60301-1.el8.noarch.rpm"),
         }[cushort]
         with open(os.environ['GITHUB_OUTPUT'], "r+") as fp:
           fp.write("CUDA_VERSION=" + full_version + "\n")

--- a/.github/workflows/rocm_build.yml
+++ b/.github/workflows/rocm_build.yml
@@ -24,7 +24,7 @@ jobs:
         python: ['3.11']
         torch_version: ['2.5.1']
         toolkit_type: ['rocm']
-        toolkit_short_version: ['6.1', '6.2']
+        toolkit_short_version: ['6.1', '6.2', '6.3']
 
     uses: ./.github/workflows/wheels_build.yml
     if: github.repository == 'rocm/xformers'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -118,5 +118,5 @@ jobs:
       aws_role: "arn:aws:iam::749337293305:role/pytorch_bot_uploader_role"
       s3_path: s3://pytorch/whl/${{ matrix.suffix }}/
       aws_s3_cp_extra_args: --acl public-read
-      filter: "*torch2.6.0+${{ matrix.suffix }}*"
+      filter: "*torch2.5.1+${{ matrix.suffix }}*"
       execute: ${{ github.repository == 'facebookresearch/xformers' && github.ref_type == 'tag' }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,9 +3,9 @@ name: wheels
 on:
   pull_request:
     paths:
-      - "packaging/compute_wheel_version.sh"
+      - ".github/compute_wheel_version.py"
       - ".github/workflows/wheel*"
-      - ".github/actions/setup-windows-runner/action.yml"
+      - ".github/actions/setup-build-cuda/action.yml"
       - "setup.py"
       - "requirements*.txt"
   push:
@@ -28,9 +28,11 @@ jobs:
         import itertools
         environ = os.environ
 
-        PY_VERSIONS = ['3.8', '3.9', '3.10', '3.11', '3.12']
-        CU_VERSIONS = ['118', '121', '124']
-        ROCM_VERSIONS = ["6.0", "6.1"]
+        PY_VERSIONS = ['3.9', '3.10', '3.11', '3.12']
+        # NOTE: Don't forget to update `upload_pt`'s matrix
+        # when changing the CUDA/ROCM versions below!
+        CU_VERSIONS = ['118', '121', '124', '126']
+        ROCM_VERSIONS = ['6.1', '6.2', '6.3'] # <- 6.0 broken in `manylinux_2_28`
         PY_CU = list(itertools.product(PY_VERSIONS, CU_VERSIONS))
         PY_ROCM = list(itertools.product(PY_VERSIONS, ROCM_VERSIONS))
         print("Full matrix PY_CU", PY_CU)
@@ -44,9 +46,12 @@ jobs:
 
         include = []
         for os in ['8-core-ubuntu', 'windows-8-core']:
-          for torch_version in ['2.4.0']:
+          for torch_version in ['2.5.1']:
             # CUDA builds
             for python, cuda_short_version in PY_CU:
+              if cuda_short_version != "124" and "windows" in os:
+                print("Windows builder no longer compatible with cu<124")
+                continue
               include.append(dict(
                 os=os,
                 python=python,
@@ -91,48 +96,25 @@ jobs:
     uses: ./.github/workflows/wheels_upload_pip.yml
     with:
       twine_username: __token__
-      filter: "*torch2.4.0+cu121*"
+      filter: "*torch2.5.1+cu121*"
       execute: ${{ github.repository == 'facebookresearch/xformers' && github.event_name != 'pull_request' }}
     secrets:
       twine_password: ${{ secrets.PYPI_TOKEN }}
 
-  upload_pt_cu118:
+  upload_pt:
     needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        suffix:
+          - cu118
+          - cu121
+          - cu124
+          - rocm6.1
     uses: ./.github/workflows/wheels_upload_s3.yml
     with:
       aws_role: "arn:aws:iam::749337293305:role/pytorch_bot_uploader_role"
-      s3_path: s3://pytorch/whl/cu118/
+      s3_path: s3://pytorch/whl/${{ matrix.suffix }}/
       aws_s3_cp_extra_args: --acl public-read
-      filter: "*torch2.4.0+cu118*"
+      filter: "*torch2.5.1+${{ matrix.suffix }}*"
       execute: ${{ github.repository == 'facebookresearch/xformers' && github.ref_type == 'tag' }}
-
-  upload_pt_cu121:
-    needs: build
-    uses: ./.github/workflows/wheels_upload_s3.yml
-    with:
-      aws_role: "arn:aws:iam::749337293305:role/pytorch_bot_uploader_role"
-      s3_path: s3://pytorch/whl/cu121/
-      aws_s3_cp_extra_args: --acl public-read
-      filter: "*torch2.4.0+cu121*"
-      execute: ${{ github.repository == 'facebookresearch/xformers' && github.ref_type == 'tag' }}
-
-  upload_pt_rocm6_0:
-    needs: build
-    uses: ./.github/workflows/wheels_upload_s3.yml
-    with:
-      aws_role: "arn:aws:iam::749337293305:role/pytorch_bot_uploader_role"
-      s3_path: s3://pytorch/whl/rocm6.0/
-      aws_s3_cp_extra_args: --acl public-read
-      filter: "*torch2.4.0+rocm6.0*"
-      execute: ${{ github.repository == 'facebookresearch/xformers' && github.ref_type == 'tag' }}
-
-  upload_pt_rocm6_1:
-    needs: build
-    uses: ./.github/workflows/wheels_upload_s3.yml
-    with:
-      aws_role: "arn:aws:iam::749337293305:role/pytorch_bot_uploader_role"
-      s3_path: s3://pytorch/whl/rocm6.1/
-      aws_s3_cp_extra_args: --acl public-read
-      filter: "*torch2.4.0+rocm6.1*"
-      execute: ${{ github.repository == 'facebookresearch/xformers' && github.ref_type == 'tag' }}
-

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -111,6 +111,8 @@ jobs:
           - cu121
           - cu124
           - rocm6.1
+          - rocm6.2
+          - rocm6.3
     uses: ./.github/workflows/wheels_upload_s3.yml
     with:
       aws_role: "arn:aws:iam::749337293305:role/pytorch_bot_uploader_role"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -118,5 +118,5 @@ jobs:
       aws_role: "arn:aws:iam::749337293305:role/pytorch_bot_uploader_role"
       s3_path: s3://pytorch/whl/${{ matrix.suffix }}/
       aws_s3_cp_extra_args: --acl public-read
-      filter: "*torch2.5.1+${{ matrix.suffix }}*"
+      filter: "*torch2.6.0+${{ matrix.suffix }}*"
       execute: ${{ github.repository == 'facebookresearch/xformers' && github.ref_type == 'tag' }}


### PR DESCRIPTION
- Pytorch supports cuda 12.6 and rocm 6.2.4, 6.3
Better performance rocm6.3 https://community.amd.com/t5/ai/unlocking-new-horizons-in-ai-and-hpc-with-the-release-of-amd/ba-p/726434

```bash
pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu126
pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.2.4
pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/rocm6.3
```

@tenpercent now synchronized with last develop commit