### PR TITLE
Remove using splitkv kernel from fmha fwd training path

### DIFF
--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
@@ -8,11 +8,7 @@
 
 #include <algorithm>
 #include "ck_tiled_fmha_fwd_setting.h"
-#include "ck_tiled_fmha_fwd_splitkv_smallq_selector.h"
 #include "ck_tiled_fmha_grouped_forward_dispatch.h"
-#include "ck_tiled_fmha_grouped_forward_splitkv_dispatch.h"
-#include "ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h"
-#include "ck_tiled_fmha_seqlen_q_switch.h"
 
 template <
     typename ScalarType,
@@ -23,52 +19,24 @@ template <
 void run_grouped_forward_mask_bias_dropout_dispatch(
     GroupedForwardParams& param,
     hipStream_t stream) {
-  // currently split-kv implementation does not support:
-  // (*) dropout
-  // (*) head dimension > 256
   if constexpr (!kHasDropout) {
-    if (param.use_split_kv && MaxK <= 256) {
-      if constexpr (MaxK <= 256) {
-        if (use_splitkv_smallq(
-                param.max_seqlen_q, std::max(param.K, param.Kv))) {
-          grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch<
-              ScalarType,
-              kHasMask,
-              kHasBias,
-              MaxK>::Run(param, stream);
-        } else {
-          FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
-            grouped_forward_splitkv_mask_bias_dropout_dispatch<
-                ScalarType,
-                kHasMask,
-                kHasBias,
-                MaxK,
-                MaxSeqlenQ>::Run(param, stream);
-          });
-        }
-      } else {
-        // Unreachable. Do not instantiate split-kv pipelines with head
-        // dimension > 256
-      }
-    } else {
-      if (get_fmha_fwd_mtile(param.num_batches, param.Hq, param.max_seqlen_q) ==
-          128)
-        grouped_forward_mask_bias_dropout_dispatch<
-            ScalarType,
-            kHasMask,
-            kHasBias,
-            kHasDropout,
-            MaxK,
-            128>::Run(param, stream);
-      else
-        grouped_forward_mask_bias_dropout_dispatch<
-            ScalarType,
-            kHasMask,
-            kHasBias,
-            kHasDropout,
-            MaxK,
-            64>::Run(param, stream);
-    }
+    if (get_fmha_fwd_mtile(param.num_batches, param.Hq, param.max_seqlen_q) ==
+        128)
+      grouped_forward_mask_bias_dropout_dispatch<
+          ScalarType,
+          kHasMask,
+          kHasBias,
+          kHasDropout,
+          MaxK,
+          128>::Run(param, stream);
+    else
+      grouped_forward_mask_bias_dropout_dispatch<
+          ScalarType,
+          kHasMask,
+          kHasBias,
+          kHasDropout,
+          MaxK,
+          64>::Run(param, stream);
   } else {
     // at present, dropout of fwd kernel requires 32x32 WarpTile
     grouped_forward_mask_bias_dropout_dispatch<


### PR DESCRIPTION
This PR removes using the fmha fwd splitkv kernel for fmha-fwd training, since we found that there were several test_backward cases with which the backward result dKey failed the checking.  which probably was caused by the inaccuracy or error in the lse output of the splitkv kernel. 

The following files will not be used after the updating, but they are kept at present:
```c++
 xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_dispatch.h
 xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h
 xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_dispatch.h
 xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h
```