### PR TITLE
Revert "Remove using splitkv kernel from fmha fwd training path"

### DIFF
--- a/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_generic_ck_tiled.cpp
@@ -247,9 +247,7 @@ efficient_attention_forward_ck(
         get_num_kv_splits_heuristic(p.B, p.Hq, p.M, std::max(p.K, p.Kv), 8);
 
     // 1) fmha fwd split-kv kernel does not support dropout
-    // 2) Don't use split-kv for fmha-fwd training path
-    p.use_split_kv =
-        (!use_dropout && !p.compute_logsumexp && use_split_kv) ? true : false;
+    p.use_split_kv = (!use_dropout && use_split_kv) ? true : false;
 
     p.num_kv_splits = num_kv_splits;
 
@@ -399,11 +397,8 @@ efficient_attention_forward_ck(
 
     // 1) fmha fwd split-kv kernel does not support dropout
     // 2) Paged-KVcache is only available from the split-kv kernel at present
-    // 3) Don't use split-kv for fmha-fwd training path
-    p.use_split_kv = (p.use_paged_kvcache ||
-                      (!use_dropout && !p.compute_logsumexp && use_split_kv))
-        ? true
-        : false;
+    p.use_split_kv =
+        (p.use_paged_kvcache || (!use_dropout && use_split_kv)) ? true : false;
 
     p.num_kv_splits = num_kv_splits;
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_forward.h
@@ -8,7 +8,11 @@
 
 #include <algorithm>
 #include "ck_tiled_fmha_batched_forward_dispatch.h"
+#include "ck_tiled_fmha_batched_forward_splitkv_dispatch.h"
+#include "ck_tiled_fmha_batched_forward_splitkv_smallq_dispatch.h"
 #include "ck_tiled_fmha_fwd_setting.h"
+#include "ck_tiled_fmha_fwd_splitkv_smallq_selector.h"
+#include "ck_tiled_fmha_seqlen_q_switch.h"
 
 template <
     typename ScalarType,
@@ -19,23 +23,50 @@ template <
 void run_batched_forward_mask_bias_dropout_dispatch(
     BatchedForwardParams& param,
     hipStream_t stream) {
+  // currently split-kv implementation does not support:
+  // (*) dropout
+  // (*) head dimension > 256
   if constexpr (!kHasDropout) {
-    if (get_fmha_fwd_mtile(param.B, param.Hq, param.M) == 128)
-      batched_forward_mask_bias_dropout_dispatch<
-          ScalarType,
-          kHasMask,
-          kHasBias,
-          kHasDropout,
-          MaxK,
-          128>::Run(param, stream);
-    else
-      batched_forward_mask_bias_dropout_dispatch<
-          ScalarType,
-          kHasMask,
-          kHasBias,
-          kHasDropout,
-          MaxK,
-          64>::Run(param, stream);
+    if (param.use_split_kv && MaxK <= 256) {
+      if constexpr (MaxK <= 256) {
+        if (use_splitkv_smallq(param.M, std::max(param.K, param.Kv))) {
+          batched_forward_splitkv_smallq_mask_bias_dropout_dispatch<
+              ScalarType,
+              kHasMask,
+              kHasBias,
+              MaxK>::Run(param, stream);
+        } else {
+          FMHA_FWD_SEQLEN_Q_SWITCH(param.M, MaxSeqlenQ, [&] {
+            batched_forward_splitkv_mask_bias_dropout_dispatch<
+                ScalarType,
+                kHasMask,
+                kHasBias,
+                MaxK,
+                MaxSeqlenQ>::Run(param, stream);
+          });
+        }
+      } else {
+        // Unreachable. Do not instantiate split-kv pipelines with head
+        // dimension > 256
+      }
+    } else {
+      if (get_fmha_fwd_mtile(param.B, param.Hq, param.M) == 128)
+        batched_forward_mask_bias_dropout_dispatch<
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK,
+            128>::Run(param, stream);
+      else
+        batched_forward_mask_bias_dropout_dispatch<
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK,
+            64>::Run(param, stream);
+    }
   } else {
     // at present, dropout of fwd kernel requires 32x32 WarpTile
     batched_forward_mask_bias_dropout_dispatch<

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_forward.h
@@ -8,7 +8,11 @@
 
 #include <algorithm>
 #include "ck_tiled_fmha_fwd_setting.h"
+#include "ck_tiled_fmha_fwd_splitkv_smallq_selector.h"
 #include "ck_tiled_fmha_grouped_forward_dispatch.h"
+#include "ck_tiled_fmha_grouped_forward_splitkv_dispatch.h"
+#include "ck_tiled_fmha_grouped_forward_splitkv_smallq_dispatch.h"
+#include "ck_tiled_fmha_seqlen_q_switch.h"
 
 template <
     typename ScalarType,
@@ -19,24 +23,52 @@ template <
 void run_grouped_forward_mask_bias_dropout_dispatch(
     GroupedForwardParams& param,
     hipStream_t stream) {
+  // currently split-kv implementation does not support:
+  // (*) dropout
+  // (*) head dimension > 256
   if constexpr (!kHasDropout) {
-    if (get_fmha_fwd_mtile(param.num_batches, param.Hq, param.max_seqlen_q) ==
-        128)
-      grouped_forward_mask_bias_dropout_dispatch<
-          ScalarType,
-          kHasMask,
-          kHasBias,
-          kHasDropout,
-          MaxK,
-          128>::Run(param, stream);
-    else
-      grouped_forward_mask_bias_dropout_dispatch<
-          ScalarType,
-          kHasMask,
-          kHasBias,
-          kHasDropout,
-          MaxK,
-          64>::Run(param, stream);
+    if (param.use_split_kv && MaxK <= 256) {
+      if constexpr (MaxK <= 256) {
+        if (use_splitkv_smallq(
+                param.max_seqlen_q, std::max(param.K, param.Kv))) {
+          grouped_forward_splitkv_smallq_mask_bias_dropout_dispatch<
+              ScalarType,
+              kHasMask,
+              kHasBias,
+              MaxK>::Run(param, stream);
+        } else {
+          FMHA_FWD_SEQLEN_Q_SWITCH(param.max_seqlen_q, MaxSeqlenQ, [&] {
+            grouped_forward_splitkv_mask_bias_dropout_dispatch<
+                ScalarType,
+                kHasMask,
+                kHasBias,
+                MaxK,
+                MaxSeqlenQ>::Run(param, stream);
+          });
+        }
+      } else {
+        // Unreachable. Do not instantiate split-kv pipelines with head
+        // dimension > 256
+      }
+    } else {
+      if (get_fmha_fwd_mtile(param.num_batches, param.Hq, param.max_seqlen_q) ==
+          128)
+        grouped_forward_mask_bias_dropout_dispatch<
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK,
+            128>::Run(param, stream);
+      else
+        grouped_forward_mask_bias_dropout_dispatch<
+            ScalarType,
+            kHasMask,
+            kHasBias,
+            kHasDropout,
+            MaxK,
+            64>::Run(param, stream);
+    }
   } else {
     // at present, dropout of fwd kernel requires 32x32 WarpTile
     grouped_forward_mask_bias_dropout_dispatch<


### PR DESCRIPTION
This reverts commit 84883b5db2fd0bb5256e451b5bd61836730445f8.

This revert is needed for enabling the good performance of `memory_efficient_attention_partitial` on ck.  

Specifically we need this revert to make the following scripts has good performance on xformers/ck 

```bash
import torch

import xformers.ops
from xformers.attn_bias_utils import create_attn_bias, pack_kv_cache
from xformers.ops import fmha
from xformers.ops.fmha import ALL_BW_OPS, ALL_FW_OPS
from xformers.ops.fmha.common import AttentionFwOpBase, AttentionOpBase
from xformers.utils import do_bench_cudagraph

def benchmark_memory_efficient_attention_partial():
    tree_size = 8
    H = 8
    D = 128
    for tree_size in [7, 13, 26, 64, 81, 121]:
        for B in [1, 2, 4, 8, 16, 32]:
            for G in [1, 2]:
                for Mk in [2048, 4096, 8192]:
                    q = torch.randn(
                        [1, B * tree_size, G, H, D], device="cuda", dtype=torch.bfloat16
                    )
                    k = torch.randn(
                        [1, B * Mk, G, H, D], device="cuda", dtype=torch.bfloat16
                    )
                    v = torch.randn(
                        [1, B * Mk, G, H, D], device="cuda", dtype=torch.bfloat16
                    )
                    attn_bias = fmha.attn_bias.BlockDiagonalPaddedKeysMask.from_seqlens(
                        q_seqlen=[tree_size for _ in range(B)],
                        kv_seqlen=torch.randint(
                            1, Mk + 1, size=(B,), device="cuda"
                        ).tolist(),
                        kv_padding=Mk,
                    )
                    torch.cuda.synchronize()
                    bench_stream = torch.cuda.Stream()
                    with torch.cuda.stream(bench_stream):
                        t_optimized_ms_triton = do_bench_cudagraph(
                            lambda: fmha.memory_efficient_attention_partial(
                                q,
                                k,
                                v,
                                attn_bias=attn_bias,
                                op=fmha.triton_splitk.FwOp,
                            )
                        )
                    torch.cuda.synchronize()
                    bench_stream = torch.cuda.Stream()
                    with torch.cuda.stream(bench_stream):
                        t_optimized_ms_ck = do_bench_cudagraph(
                            lambda: fmha.memory_efficient_attention_partial(
                                q,
                                k,
                                v,
                                attn_bias=attn_bias,
                                op=fmha.ck.FwOp,
                            )
                        )
                    triton_faster = t_optimized_ms_ck > t_optimized_ms_triton
                    print(
                        f"{B=}, {G=}, {Mk=}, {tree_size=}: "
                        f"memory_efficient_attention_partial with CK took {t_optimized_ms_ck * 1e3:.1f}us, "
                        f"with Triton Split-K took {t_optimized_ms_triton * 1e3:.1f}us, "
                        f"Triton faster: {triton_faster}. "
                    )

if __name__ == "__main__":
    benchmark_memory_efficient_attention_partial()

```
