### PR TITLE
add environment knob for turning off ck fmha

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -519,7 +519,7 @@ def get_extensions():
             "--ptxas-options=-O2",
             "--ptxas-options=-allow-expensive-optimizations=true",
         ]
-    elif torch.version.hip and (
+    elif torch.version.hip and os.getenv("XFORMERS_CK_FLASH_ATTN", "1") == "1" and (
         torch.cuda.is_available() or os.getenv("HIP_ARCHITECTURES", "") != ""
     ):
         rename_cpp_cu(source_hip)


### PR DESCRIPTION
## What does this PR do?
Enables building xformers on ROCm without building CK kernels.

```
XFORMERS_CK_FLASH_ATTN=0 python setup.py develop
```

The default is to build the extension, so that the existing workflows don't break

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
