### PR TITLE
Update rocm xformers dockerfile

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -1,5 +1,5 @@
 ARG XFORMERS_COMPILE_JOBS=128
-ARG HIP_ARCHITECTURES="gfx90a gfx942"
+ARG HIP_ARCHITECTURE="gfx942"
 
 FROM quay.io/pypa/manylinux_2_28_x86_64 as rocm
 
@@ -7,7 +7,7 @@ RUN set -ex && \
   usermod -a -G render,video $(whoami) && \
   dnf -y install https://www.elrepo.org/elrepo-release-8.el8.elrepo.noarch.rpm && \
   dnf config-manager --set-enabled elrepo-kernel && \
-  dnf -y install https://repo.radeon.com/amdgpu-install/6.2.2/rhel/8.10/amdgpu-install-6.2.60202-1.el8.noarch.rpm
+  dnf -y install https://repo.radeon.com/amdgpu-install/6.4.4/rhel/8.10/amdgpu-install-6.4.60404-1.el8.noarch.rpm
 
 RUN set -ex && \
   dnf -y install amdgpu-dkms rocm 
@@ -26,15 +26,16 @@ RUN set -ex && \
 RUN set -ex && \
   cd /opt/xformers && \
   uv pip install ninja && \
-  uv pip install -r requirements.txt --extra-index-url=https://download.pytorch.org/whl/nightly/rocm6.2 && \
+  uv pip install -r requirements.txt --extra-index-url=https://download.pytorch.org/whl/rocm6.4 && \
   uv pip install -r requirements-test.txt && \
   uv pip install -r requirements-benchmark.txt && \
   uv pip list
 
 ARG XFORMERS_COMPILE_JOBS
 ENV MAX_JOBS=${XFORMERS_COMPILE_JOBS} 
-ARG HIP_ARCHITECTURES
-ENV HIP_ARCHITECTURES=${HIP_ARCHITECTURES} 
+ARG HIP_ARCHITECTURE
+ENV HIP_ARCHITECTURE=${HIP_ARCHITECTURE}
+ENV XFORMERS_CK_FLASH_ATTN=1
 RUN set -ex && \
   cd /opt/xformers && \
   uv build . --wheel --no-build-isolation --verbose --offline && \


### PR DESCRIPTION
## What does this PR do?
This PR aim to fix xformers build issue on ROCm platform with composable kernel support. 
- Update ROCm version from 6.2.2 to 6.4.4 to support minimal pytorch requirement (torch >=2.7.0)
- Explicit set `XFORMERS_CK_FLASH_ATTN=1` and use `HIP_ARCHITECTURE` instead of `HIP_ARCHITECTURES` to meet following condition to enable composable kernel during docker build: https://github.com/ROCm/xformers/blob/c9911ff92da5dbe5a6baeafc7ab8eb20e85f00f8/setup.py#L576-L580

BTW, it seems current `setup.py` can only support compilation on the single target gfx architecture due to different compilation option: 
https://github.com/ROCm/xformers/blob/c9911ff92da5dbe5a6baeafc7ab8eb20e85f00f8/setup.py#L606-L613
## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/xformers/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/xformers/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
