### PR TITLE
Initial RDNA Windows bring-up for CK FMHA

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,19 +144,32 @@ def get_cuda_version(cuda_dir) -> int:
 
 
 def get_hip_version(rocm_dir) -> Optional[str]:
-    hipcc_bin = "hipcc" if rocm_dir is None else os.path.join(rocm_dir, "bin", "hipcc")
-    try:
-        raw_output = subprocess.check_output(
-            [hipcc_bin, "--version"], universal_newlines=True
-        )
-    except Exception as e:
-        print(
-            f"hip installation not found: {e} ROCM_PATH={os.environ.get('ROCM_PATH')}"
-        )
+    candidates: List[str] = []
+    if rocm_dir is not None:
+        # Standard Linux layout
+        candidates.append(os.path.join(rocm_dir, "bin", "hipcc"))
+        # Some Windows ROCm distributions (e.g. TheRock) place hipcc directly
+        # under the venv Scripts dir; rocm_dir may already point there.
+        candidates.append(os.path.join(rocm_dir, "hipcc"))
+    # Fall back to PATH lookup
+    candidates.append("hipcc")
+    last_error: Optional[Exception] = None
+    for hipcc_bin in candidates:
+        try:
+            raw_output = subprocess.check_output(
+                [hipcc_bin, "--version"], universal_newlines=True
+            )
+        except Exception as e:
+            last_error = e
+            continue
+        for line in raw_output.split("\n"):
+            if "HIP version" in line:
+                return line.split()[-1]
         return None
-    for line in raw_output.split("\n"):
-        if "HIP version" in line:
-            return line.split()[-1]
+    print(
+        f"hip installation not found: {last_error} "
+        f"ROCM_PATH={os.environ.get('ROCM_PATH')}"
+    )
     return None
 
 
@@ -394,18 +407,76 @@ def get_flash_attention3_extensions(cuda_version: int, extra_compile_args):
 
 
 def rename_cpp_cu(cpp_files):
+    # Only overwrite the .cu copy if the source has actually changed. shutil.copy
+    # always bumps mtime, which invalidates ninja's incremental cache and forces
+    # a full HIP rebuild every invocation.
     for entry in cpp_files:
-        shutil.copy(entry, os.path.splitext(entry)[0] + ".cu")
+        dst = os.path.splitext(entry)[0] + ".cu"
+        if os.path.exists(dst):
+            try:
+                with open(entry, "rb") as f1, open(dst, "rb") as f2:
+                    if f1.read() == f2.read():
+                        continue
+            except OSError:
+                pass
+        shutil.copy(entry, dst)
+
+
+def get_rocm_root() -> Optional[str]:
+    """Locate the ROCm SDK root (the dir containing bin/, lib/llvm/, etc.).
+
+    Needed on Windows: hipcc forwards compile commands to clang but doesn't
+    pass `--rocm-path`, so clang fails to find the device library bitcode.
+    The TheRock SDK lives at venv/Lib/site-packages/_rocm_sdk_devel; we
+    discover it via the bundled `rocm-sdk` helper, then fall back to env
+    vars or hipcc's binary location.
+    """
+    # 1) Use the rocm-sdk helper if installed (TheRock).
+    try:
+        out = subprocess.check_output(
+            ["rocm-sdk", "path", "--root"], universal_newlines=True
+        ).strip()
+        if out and os.path.isdir(out):
+            return out
+    except Exception:
+        pass
+    # 2) Standard env vars.
+    for key in ("ROCM_HOME", "ROCM_PATH", "HIP_PATH"):
+        val = os.environ.get(key)
+        if val and os.path.isdir(val) and os.path.isdir(
+            os.path.join(val, "lib", "llvm", "amdgcn", "bitcode")
+        ):
+            return val
+    # 3) Walk up from hipcc's location.
+    hipcc = shutil.which("hipcc")
+    if hipcc:
+        # hipcc usually lives at <root>/bin/hipcc; walk up one level.
+        candidate = os.path.dirname(os.path.dirname(os.path.realpath(hipcc)))
+        if os.path.isdir(
+            os.path.join(candidate, "lib", "llvm", "amdgcn", "bitcode")
+        ):
+            return candidate
+    return None
 
 
 def get_rocm_agent_arch():
+    # 1) Linux: rocm_agent_enumerator if present.
     exec_path = "/opt/rocm/bin/rocm_agent_enumerator"
     if os.path.isfile(exec_path) and os.access(exec_path, os.X_OK):
         arches = subprocess.check_output([exec_path], universal_newlines=True)
-        arch_list = arches.strip().split()
-        return arch_list[0]
-    else:
-        return "gfx942"
+        arch_list = [a for a in arches.strip().split() if a and a != "gfx000"]
+        if arch_list:
+            return arch_list[0]
+    # 2) Cross-platform: ask torch (works on Windows ROCm via TheRock).
+    try:
+        if torch.cuda.is_available() and torch.version.hip:
+            arch_name = torch.cuda.get_device_properties(0).gcnArchName
+            # gcnArchName looks like "gfx1200" or "gfx942:sramecc+:xnack-"; strip features.
+            return arch_name.split(":")[0]
+    except Exception as e:
+        print(f"torch-based GPU arch detection failed: {e}")
+    # 3) Last-resort fallback (preserves prior behaviour).
+    return "gfx942"
 
 
 def get_extensions():
@@ -580,10 +651,20 @@ def get_extensions():
     ):
         rename_cpp_cu(source_hip)
         hip_version = get_hip_version(ROCM_HOME)
+        rocm_root = get_rocm_root()
 
         source_hip_cu = []
         for ff in source_hip:
             source_hip_cu += [ff.replace(".cpp", ".cu")]
+
+        # Mirror the CUDA-side XFORMERS_SELECTIVE_BUILD filter above so ROCm
+        # users also get a substring knob for dev-time iteration. Like the
+        # CUDA version, this is sharp-edged: the pattern must be wide enough
+        # to keep every instance referenced by the dispatcher TUs that remain
+        # in the build, or the link will fail.
+        if "XFORMERS_SELECTIVE_BUILD" in os.environ:
+            pattern = os.environ["XFORMERS_SELECTIVE_BUILD"]
+            source_hip_cu = [f for f in source_hip_cu if pattern in str(f)]
 
         extension = CUDAExtension
         sources += source_hip_cu
@@ -608,26 +689,68 @@ def get_extensions():
         if arch == "native":
             arch = get_rocm_agent_arch()
 
-        if arch not in ["gfx908", "gfx90a", "gfx942", "gfx950"]:
+        # CDNA archs use MFMA. RDNA archs (gfx11xx / gfx12xx) use WMMA — the
+        # xformers wrapper layer also needs FMHA_BUILD_ON_GFX11/GFX12 defines
+        # so the per-arch warp_tile / pipeline selection picks WMMA-friendly
+        # shapes. CK tile itself supports both.
+        cdna_archs = ["gfx908", "gfx90a", "gfx942", "gfx950"]
+        rdna3_archs = [
+            "gfx1100", "gfx1101", "gfx1102", "gfx1103",
+            "gfx1150", "gfx1151", "gfx1152", "gfx1153",
+        ]
+        rdna4_archs = ["gfx1200", "gfx1201"]
+
+        if arch not in cdna_archs + rdna3_archs + rdna4_archs:
             raise ValueError(f"Not supported AMD GPU arch: {arch}")
 
         if arch == "gfx950":
             cc_flag += ["-DFMHA_BUILD_ON_GFX950"]
+        elif arch in rdna3_archs:
+            cc_flag += ["-DFMHA_BUILD_ON_GFX11"]
+        elif arch in rdna4_archs:
+            cc_flag += ["-DFMHA_BUILD_ON_GFX12"]
 
         offload_compress_flag = []
         if hip_version >= "6.2.":
             offload_compress_flag = ["--offload-compress"]
 
+        # MSVC's UCRT marks std::getenv as _CRT_INSECURE_DEPRECATE, which fires
+        # -Wdeprecated-declarations inside ck_tile/core/utility/env.hpp. That
+        # header is transitively included by virtually every HIP TU, so under
+        # -Werror the Windows build fails to link. Only silence this class of
+        # warning on Windows — Linux/CDNA keeps -Werror enforcement unchanged.
+        windows_warning_flags = (
+            ["-Wno-deprecated-declarations"]
+            if platform.system() == "Windows"
+            else []
+        )
+
+        rocm_path_flag: List[str] = []
+        if rocm_root is not None:
+            rocm_path_flag.append(f"--rocm-path={rocm_root}")
+            # TheRock layout puts the device-library bitcode at
+            # <root>/lib/llvm/amdgcn/bitcode rather than the upstream
+            # <root>/amdgcn/bitcode that clang's --rocm-path discovery
+            # expects. Pass the explicit override so clang can resolve
+            # oclc_isa_version_*.bc et al.
+            device_lib = os.path.join(
+                rocm_root, "lib", "llvm", "amdgcn", "bitcode"
+            )
+            if os.path.isdir(device_lib):
+                rocm_path_flag.append(f"--rocm-device-lib-path={device_lib}")
+
         extra_compile_args["nvcc"] = [
             "-O3",
             "-std=c++20",
             f"--offload-arch={arch}",
+            *rocm_path_flag,
             *offload_compress_flag,
             "-U__CUDA_NO_HALF_OPERATORS__",
             "-U__CUDA_NO_HALF_CONVERSIONS__",
             "-DCK_TILE_FMHA_FWD_FAST_EXP2=1",
             "-fgpu-flush-denormals-to-zero",
             "-Werror",
+            *windows_warning_flags,
             "-Wno-c++11-narrowing",
             "-Woverloaded-virtual",
             "-Wno-unknown-warning-option",

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_warp_tile_define.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_warp_tile_define.h
@@ -8,6 +8,18 @@
 
 #include <ck_tile/core.hpp>
 
+#if defined(FMHA_BUILD_ON_GFX11) || defined(FMHA_BUILD_ON_GFX12)
+// RDNA WMMA only registers 16x16x16 in CK tile's warp_gemm dispatcher for
+// fp16 / bf16 (and fp8 / int8). The xformers wrapper layer was authored for
+// CDNA MFMA shapes (32x32x16 and 16x16x32). To keep the per-arch *_setting.h
+// headers small, we alias all three names down to the WMMA-supported shape.
+// Block tile geometry is unchanged — each warp simply issues more WMMA
+// instructions to cover the same output tile.
+using WarpTile_32x32x16 = ck_tile::sequence<16, 16, 16>;
+using WarpTile_16x16x32 = ck_tile::sequence<16, 16, 16>;
+using WarpTile_16x16x16 = ck_tile::sequence<16, 16, 16>;
+#else
 using WarpTile_32x32x16 = ck_tile::sequence<32, 32, 16>;
 using WarpTile_16x16x32 = ck_tile::sequence<16, 16, 32>;
 using WarpTile_16x16x16 = ck_tile::sequence<16, 16, 16>;
+#endif

--- a/xformers/ops/differentiable_collectives.py
+++ b/xformers/ops/differentiable_collectives.py
@@ -4,10 +4,16 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import torch
 import torch.distributed
+
+if TYPE_CHECKING:
+    # torch.distributed.Work is not exposed on every build (notably Windows
+    # ROCm / TheRock), so we only import it for type checkers. The runtime
+    # annotation is a forward-ref string that is never evaluated.
+    from torch.distributed import Work
 
 
 def all_reduce(
@@ -24,7 +30,7 @@ def all_reduce(
 
 def gather_along_first_dim_async(
     input_: torch.Tensor, *, process_group: torch.distributed.ProcessGroup
-) -> Tuple[torch.Tensor, Optional[torch.distributed.Work]]:
+) -> Tuple[torch.Tensor, Optional["Work"]]:
     mp_size = process_group.size()
     if mp_size == 1:
         return input_, None
@@ -42,7 +48,7 @@ def gather_along_first_dim_async(
 
 def reduce_scatter_along_first_dim_async(
     input_: torch.Tensor, *, process_group: torch.distributed.ProcessGroup
-) -> Tuple[torch.Tensor, Optional[torch.distributed.Work]]:
+) -> Tuple[torch.Tensor, Optional["Work"]]:
     mp_size = process_group.size()
     if mp_size == 1:
         return input_, None

--- a/xformers/ops/seqpar.py
+++ b/xformers/ops/seqpar.py
@@ -7,7 +7,15 @@
 from typing import Callable, List, Tuple
 
 import torch
-from torch.distributed.distributed_c10d import _resolve_process_group
+
+# Some torch builds (e.g. Windows ROCm / TheRock) ship a stripped-down
+# torch.distributed without distributed_c10d. Importing this module must not
+# break xformers for single-GPU users; the fallback is only reachable if one
+# of the sequence-parallel ops below is actually called.
+try:
+    from torch.distributed.distributed_c10d import _resolve_process_group
+except ImportError:
+    _resolve_process_group = None  # type: ignore[assignment]
 
 from .differentiable_collectives import (
     gather_along_first_dim,

--- a/xformers/ops/sequence_parallel_fused_ops.py
+++ b/xformers/ops/sequence_parallel_fused_ops.py
@@ -9,7 +9,15 @@ from typing import Callable, Dict, List, Optional, overload, Sequence, Union
 import torch
 import torch.distributed as dist
 import torch.multiprocessing.reductions
-from torch.distributed._symmetric_memory import get_symm_mem_workspace
+
+# torch.distributed._symmetric_memory is absent from some torch builds
+# (e.g. Windows ROCm / TheRock). Guard the import so xformers stays usable
+# on single-GPU; the None fallback is only reached if the fused ops below
+# are actually invoked.
+try:
+    from torch.distributed._symmetric_memory import get_symm_mem_workspace
+except ImportError:
+    get_symm_mem_workspace = None  # type: ignore[assignment]
 
 OP_FINISHED_CHANNEL = 0
 COMMS_READY_CHANNEL = 1


### PR DESCRIPTION
## What does this PR do?

Progress on #83.

Enables the CK-tile FMHA kernel family on RDNA3 and RDNA4 to be built and imported on Windows with [TheRock ROCm](https://github.com/ROCm/TheRock). No changes to Linux/CDNA behavior are introduced.

Three logical pieces:

1. **`setup.py`** - RDNA arch whitelist + `FMHA_BUILD_ON_GFX11`/`FMHA_BUILD_ON_GFX12` defines, TheRock SDK discovery, clang `--rocm-path` + device-lib overrides, torch-based arch detection fallback, multi-location hipcc lookup, `XFORMERS_SELECTIVE_BUILD` mirrored for HIP sources, Windows-only `-Wno-deprecated-declarations`, and a `rename_cpp_cu` content-skip that stops busting ninja's incremental cache on every invocation.
2. **`ck_tiled_fmha_warp_tile_define.h`** - on RDNA, alias `WarpTile_32x32x16` / `WarpTile_16x16x32` / `WarpTile_16x16x16` down to the single WMMA shape that CK-tile's `warp_gemm` dispatcher registers for fp16/bf16 on RDNA (`16x16x16`). Gated on `FMHA_BUILD_ON_GFX11 || FMHA_BUILD_ON_GFX12`; CDNA is unchanged.
3. **`xformers/ops/*.py`** - three `torch.distributed` imports guarded with `TYPE_CHECKING` / `try-except ImportError`. TheRock's torch build omits `torch.distributed.Work`, `torch.distributed.distributed_c10d`, and `torch.distributed._symmetric_memory`, which today makes `import xformers` fail on Windows before any CUDA/HIP code runs.

### Test coverage

**What was tested:** https://github.com/ROCm/xformers/pull/84#issuecomment-4273719650

**What was not tested:**
- RDNA3. Only RDNA4 (gfx1200) was tested. The code path for RDNA3 is symmetric but unvalidated.
- Linux RDNA. Only Windows + TheRock was tested.
- All existing CDNA build paths. Changes are either CDNA-irrelevant (Windows-gated, RDNA-gated) or source-compatible (hipcc discovery, ninja cache fix, torch-based arch fallback only triggers when `rocm_agent_enumerator` is absent).

### Reproducing the tested configuration

```cmd
:: Inside a TheRock venv on Windows 11 with MSVC 2022 + gfx1200

call "...\VC\Auxiliary\Build\vcvars64.bat"
call <venv>\Scripts\activate.bat

for /f "delims=" %i in ('rocm-sdk path --root') do set ROCM_ROOT=%i
set ROCM_HOME=%ROCM_ROOT%
set ROCM_PATH=%ROCM_ROOT%
set HIP_PATH=%ROCM_ROOT%
set PATH=%ROCM_ROOT%\lib\llvm\bin;%ROCM_ROOT%\bin;%PATH%

set CC=clang-cl
set CXX=clang-cl
set DISTUTILS_USE_SDK=1

:: optional:
:: `set XFORMERS_DISABLE_BACKWARD=1` - forward-only, saves a lot of time
:: use XFORMERS_SELECTIVE_BUILD to compile only a single instance:
:: `set XFORMERS_SELECTIVE_BUILD=fmha_batched_infer_fp16_no_mask_no_bias_no_dropout_maxk_64`
:: `set HIP_ARCHITECTURE=gfx1200` - build for a specific architecture

python setup.py build_ext --inplace -j 12
```

cc @schung-amd @qianfengz @sstamenk

Based on @schung-amd’s “any help is welcome” statement in https://github.com/ROCm/xformers/issues/83#issuecomment-4261207407, I opened this PR to demonstrate the changes needed to build xFormers CK on RDNA/Windows. Would appreciate any review or feedback.