### PR TITLE
Update to random  uniform kernel and adapt to latest ck_tile fmha_bwd_kernel 

### DIFF
--- a/xformers/csrc/attention/hip_fmha/attention_backward_generic_ck_tiled.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_backward_generic_ck_tiled.cpp
@@ -158,18 +158,6 @@ efficient_attention_backward_ck(
     grad_v = at::empty(value.sizes(), value.options());
   }
 
-  at::Tensor grad_q_f32;
-  const bool use_grad_q_f32 =
-      (query.scalar_type() == at::ScalarType::BFloat16 ||
-       query.scalar_type() == at::ScalarType::Half);
-
-  if (use_grad_q_f32) {
-    grad_q_f32 = at::empty(grad_q.sizes(), opts.dtype(at::kFloat));
-    grad_q_f32.fill_(0);
-  } else {
-    grad_q.fill_(0);
-  };
-
   // CK-FlashAttn requires q/k/v to have same shapes with dQ/dK/dV respectively
   TORCH_CHECK(query.sizes() == grad_q.sizes());
   TORCH_CHECK(query.strides() == grad_q.strides());
@@ -232,11 +220,6 @@ efficient_attention_backward_ck(
     p.grad_k_ptr = is_mqa_gqa ? tmp_grad_k.data_ptr() : grad_k.data_ptr();
     p.grad_v_ptr = is_mqa_gqa ? tmp_grad_v.data_ptr() : grad_v.data_ptr();
 
-    if (use_grad_q_f32)
-      p.grad_q_f32_ptr = grad_q_f32.data_ptr();
-    else
-      p.grad_q_f32_ptr = nullptr;
-
     p.q_strides = {
         static_cast<int>(query.stride(0)),
         static_cast<int>(query.stride(1)),
@@ -267,14 +250,6 @@ efficient_attention_backward_ck(
         static_cast<int>(logsumexp.stride(0)),
         static_cast<int>(logsumexp.stride(1)),
         static_cast<int>(logsumexp.stride(2))};
-
-    if (use_grad_q_f32) {
-      p.grad_q_f32_strides = {
-          static_cast<int>(grad_q_f32.stride(0)),
-          static_cast<int>(grad_q_f32.stride(1)),
-          static_cast<int>(grad_q_f32.stride(2)),
-          static_cast<int>(grad_q_f32.stride(3))};
-    }
 
     if (is_mqa_gqa) {
       p.grad_k_strides = {
@@ -385,13 +360,6 @@ efficient_attention_backward_ck(
         static_cast<int>(logsumexp.stride(1)),
         static_cast<int>(logsumexp.stride(2))};
 
-    if (use_grad_q_f32) {
-      p.grad_q_f32_strides = {
-          static_cast<int>(grad_q_f32.stride(1)),
-          static_cast<int>(grad_q_f32.stride(2)),
-          static_cast<int>(grad_q_f32.stride(3))};
-    }
-
     if (is_mqa_gqa) {
       p.grad_k_strides = {
           static_cast<int>(tmp_grad_k.stride(1)),
@@ -439,7 +407,13 @@ efficient_attention_backward_ck(
     at::Tensor dev_seqlen_k;
 
     if (seqstart_q->is_cpu()) {
+      // both seqstart_q and seqstart_k should be cpu tensor
+      TORCH_CHECK(seqstart_k->is_cpu());
+
       dev_seqstart_q = at::empty({p.num_batches + 1}, opts.dtype(at::kInt));
+      dev_seqstart_k = at::empty({p.num_batches + 1}, opts.dtype(at::kInt));
+
+      p.seqstart_q_host_ptr = reinterpret_cast<int*>(seqstart_q->data_ptr());
       p.seqstart_q_dev_ptr = dev_seqstart_q.data_ptr();
       HIP_CALL_CHECK(hipMemcpyAsync(
           p.seqstart_q_dev_ptr,
@@ -447,12 +421,8 @@ efficient_attention_backward_ck(
           (p.num_batches + 1) * sizeof(int),
           hipMemcpyHostToDevice,
           stream));
-    } else
-      p.seqstart_q_dev_ptr = seqstart_q->data_ptr();
 
-    if (seqstart_k->is_cpu()) {
-      dev_seqstart_k = at::empty({p.num_batches + 1}, opts.dtype(at::kInt));
-
+      p.seqstart_k_host_ptr = reinterpret_cast<int*>(seqstart_k->data_ptr());
       p.seqstart_k_dev_ptr = dev_seqstart_k.data_ptr();
       HIP_CALL_CHECK(hipMemcpyAsync(
           p.seqstart_k_dev_ptr,
@@ -460,8 +430,15 @@ efficient_attention_backward_ck(
           (p.num_batches + 1) * sizeof(int),
           hipMemcpyHostToDevice,
           stream));
-    } else
+    } else {
+      // both seqstart_q and seqstart_k should be cuda device tensor
+      TORCH_CHECK(!seqstart_k->is_cpu());
+
+      p.seqstart_q_dev_ptr = seqstart_q->data_ptr();
       p.seqstart_k_dev_ptr = seqstart_k->data_ptr();
+      p.seqstart_q_host_ptr = nullptr;
+      p.seqstart_k_host_ptr = nullptr;
+    };
 
     if (seqlen_k.has_value()) {
       TORCH_CHECK(seqlen_k->scalar_type() == at::ScalarType::Int);
@@ -502,11 +479,6 @@ efficient_attention_backward_ck(
     p.grad_k_ptr = is_mqa_gqa ? tmp_grad_k.data_ptr() : grad_k.data_ptr();
     p.grad_v_ptr = is_mqa_gqa ? tmp_grad_v.data_ptr() : grad_v.data_ptr();
     p.grad_bias_ptr = bias_requires_grad ? grad_bias.data_ptr() : nullptr;
-
-    if (use_grad_q_f32)
-      p.grad_q_f32_ptr = grad_q_f32.data_ptr();
-    else
-      p.grad_q_f32_ptr = nullptr;
   };
 
   auto inDataType = query.scalar_type();

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_backward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_batched_backward.h
@@ -12,6 +12,7 @@
 #include <ck_tile/ops/epilogue.hpp>
 #include <ck_tile/ops/fmha.hpp>
 
+#include "ck_fmha_util.h"
 #include "ck_tiled_bool_switch.h"
 #include "ck_tiled_fmha_bwd_setting.h"
 #include "ck_tiled_fmha_params.h"
@@ -53,10 +54,6 @@ struct batched_backward_mask_bias_dropout_dispatch {
       FmhaBlockDropout,
       false, // kUseTrLoad
       FmhaTraits>;
-
-  static constexpr bool NeedConvertGradQ = !std::is_same<
-      typename FmhaBwdTypeConfig<ScalarType>::AccDataType,
-      typename FmhaBwdTypeConfig<ScalarType>::QGradDataType>::value;
 
   static void Run(BatchedBackwardParams& param, hipStream_t stream) {
     {
@@ -147,7 +144,8 @@ struct batched_backward_mask_bias_dropout_dispatch {
             RunWithBwdDQDKDVKernel<FmhaBwdDQDKDVKernel_>(param, stream);
           });
     };
-    if constexpr (NeedConvertGradQ) {
+
+    {
       constexpr ck_tile::index_t kBlockSize = 256;
 
       const bool pad_seqlen_q = !(param.M % kBlockSize == 0);
@@ -169,7 +167,6 @@ struct batched_backward_mask_bias_dropout_dispatch {
                     typename FmhaBwdTypeConfig<ScalarType>::QGradDataType,
                     kBlockSize,
                     FmhaShape::kM0,
-                    FmhaShape::kN0,
                     MaxK, // kQKHeaddim
                     false, // kIsGroupMode
                     false, // kIsDeterministic
@@ -230,6 +227,27 @@ struct batched_backward_mask_bias_dropout_dispatch {
   static void RunWithBwdDQDKDVKernel(
       BatchedBackwardParams& param,
       hipStream_t stream) {
+    auto host_ws_size = FmhaBwdDQDKDVKernel::GetWorkspaceHostSize(param.B);
+
+    // ToDo: how to release host_buf inside with/no hipGraph capturing
+    auto host_buf = new char[host_ws_size];
+    auto device_ws_size = FmhaBwdDQDKDVKernel::PrepareWorkspaceHost(
+        host_buf, param.B, param.K, param.Hq, param.M, param.N);
+    param.workspace_size = host_ws_size + device_ws_size;
+
+    char* gpu_buf;
+
+    HIP_CALL_CHECK(hipMallocAsync(&gpu_buf, param.workspace_size, stream));
+    HIP_CALL_CHECK(hipMemcpyAsync(
+        gpu_buf, host_buf, host_ws_size, hipMemcpyHostToDevice, stream));
+
+    if (FmhaBwdDQDKDVKernel::NeedsZeroDqAcc()) {
+      HIP_CALL_CHECK(
+          hipMemsetAsync(gpu_buf + host_ws_size, 0, device_ws_size, stream));
+    };
+
+    param.workspace_ptr = reinterpret_cast<uint8_t*>(gpu_buf);
+
     const auto kargs = [&] {
       return FmhaBwdDQDKDVKernel::MakeKargsImpl(
           param.q_ptr,
@@ -240,10 +258,11 @@ struct batched_backward_mask_bias_dropout_dispatch {
           param.grad_out_ptr,
           param.dot_out_ptr,
           nullptr, // rand_val_ptr
+          nullptr, // dq_ptr, only used with QrQtrDor pipeline
           param.grad_k_ptr,
           param.grad_v_ptr,
           param.grad_bias_ptr,
-          NeedConvertGradQ ? param.grad_q_f32_ptr : param.grad_q_ptr,
+          param.workspace_ptr,
           param.M, // seqlen_q
           param.N, // seqlen_k
           0, // batch, newly added
@@ -259,7 +278,7 @@ struct batched_backward_mask_bias_dropout_dispatch {
           param.attn_bias_strides[2],
           0, // stride_randval
           param.grad_out_strides[1],
-          NeedConvertGradQ ? param.grad_q_f32_strides[1] : param.q_strides[1],
+          0, // stride_dq, only used with QrQtrDor pipeline
           param.grad_k_strides[1],
           param.grad_v_strides[1],
           param.attn_bias_strides[2], // assume grad_bias has same strides as
@@ -272,7 +291,7 @@ struct batched_backward_mask_bias_dropout_dispatch {
           0, // nhead_stride_randval
           param.grad_out_strides[2],
           param.lsed_strides[1],
-          NeedConvertGradQ ? param.grad_q_f32_strides[2] : param.q_strides[2],
+          0, // nhead_stride_dq, only used with QrQtrDor pipeline
           param.grad_k_strides[2],
           param.grad_v_strides[2],
           param.attn_bias_strides[1], // assume grad_bias has same strides as
@@ -285,12 +304,11 @@ struct batched_backward_mask_bias_dropout_dispatch {
           0, // batch_stride_randval
           param.grad_out_strides[0],
           param.lsed_strides[0], // lse/dot is in BHM contiguous layout
-          NeedConvertGradQ ? param.grad_q_f32_strides[0] : param.q_strides[0],
+          0, // batch_stride_dq, // only used for QrQtrDor pipeline
           param.grad_k_strides[0],
           param.grad_v_strides[0],
           param.attn_bias_strides[0], // assume grad_bias has same strides as
                                       // bias
-          0, // split_stride_dq_acc
           (param.window_size > 0) ? param.window_size - 1
                                   : -1, // window_left_size
           (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
@@ -315,20 +333,16 @@ struct batched_backward_mask_bias_dropout_dispatch {
       hipStream_t stream) {
     const auto kargs = [&] {
       return FmhaBwdConvertQGradKernel::MakeKargs(
-          param.grad_q_f32_ptr,
+          param.workspace_ptr,
           param.grad_q_ptr,
+          param.B,
+          param.Hq,
           param.M, // seqlen_q
           param.N, // seqlen_k
           param.K, // headdim of q/k
           param.q_strides[1],
-          param.grad_q_f32_strides[1],
           param.q_strides[2],
-          param.grad_q_f32_strides[2],
-          param.q_strides[0],
-          param.grad_q_f32_strides[0],
-          0, // split_stride_dq_acc, not used
-          0, // batch_size, not used
-          0); // nhead, not used
+          param.q_strides[0]);
     }();
 
     dim3 kGridSize =
@@ -341,6 +355,10 @@ struct batched_backward_mask_bias_dropout_dispatch {
         ck_tile::stream_config{stream, false},
         ck_tile::make_kernel<kBlockPerCu>(
             FmhaBwdConvertQGradKernel{}, kGridSize, kBlockSize, 0, kargs));
+
+    if (param.workspace_size > 0) {
+      HIP_CALL_CHECK(hipFreeAsync(param.workspace_ptr, stream));
+    };
   }
 };
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_backward.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_grouped_backward.h
@@ -8,10 +8,12 @@
 
 #include <ck_tile/core/numeric/integer.hpp>
 #include <ck_tile/host/kernel_launch.hpp>
+#include <ck_tile/host/pinned_host_releaser.hpp>
 #include <ck_tile/host/stream_config.hpp>
 #include <ck_tile/ops/epilogue.hpp>
 #include <ck_tile/ops/fmha.hpp>
 
+#include "ck_fmha_util.h"
 #include "ck_tiled_bool_switch.h"
 #include "ck_tiled_fmha_bwd_setting.h"
 #include "ck_tiled_fmha_params.h"
@@ -53,10 +55,6 @@ struct grouped_backward_mask_bias_dropout_dispatch {
       FmhaBlockDropout,
       false, // kUseTrLoad, not used
       FmhaTraits>;
-
-  static constexpr bool NeedConvertGradQ = !std::is_same<
-      typename FmhaBwdTypeConfig<ScalarType>::AccDataType,
-      typename FmhaBwdTypeConfig<ScalarType>::QGradDataType>::value;
 
   static void Run(GroupedBackwardParams& param, hipStream_t stream) {
     {
@@ -146,7 +144,7 @@ struct grouped_backward_mask_bias_dropout_dispatch {
           });
     };
 
-    if constexpr (NeedConvertGradQ) {
+    {
       constexpr ck_tile::index_t kBlockSize = 128;
 
       const bool pad_seqlen_q = true;
@@ -168,7 +166,6 @@ struct grouped_backward_mask_bias_dropout_dispatch {
                     typename FmhaBwdTypeConfig<ScalarType>::QGradDataType,
                     kBlockSize,
                     64, // kM0
-                    1, // kN0, no use
                     MaxK, // kQKHeaddim
                     true, // kIsGroupMode
                     false, // kIsDeterministic
@@ -228,6 +225,134 @@ struct grouped_backward_mask_bias_dropout_dispatch {
   static void RunWithBwdDQDKDVKernel(
       GroupedBackwardParams& param,
       hipStream_t stream) {
+    if (param.seqstart_q_host_ptr != nullptr) {
+      auto host_ws_size =
+          FmhaBwdDQDKDVKernel::GetWorkspaceHostSize(param.num_batches);
+
+      void* host_buf;
+
+      HIP_CALL_CHECK(hipHostMalloc(&host_buf, host_ws_size));
+      auto device_ws_size = FmhaBwdDQDKDVKernel::PrepareWorkspaceHost(
+          host_buf,
+          param.num_batches,
+          param.K,
+          param.Hq,
+          param.M,
+          param.N,
+          param.seqstart_q_host_ptr,
+          param.seqstart_k_host_ptr);
+      param.workspace_size = host_ws_size + device_ws_size;
+
+      char* gpu_buf;
+
+      HIP_CALL_CHECK(hipMallocAsync(&gpu_buf, param.workspace_size, stream));
+      HIP_CALL_CHECK(hipMemcpyAsync(
+          gpu_buf, host_buf, host_ws_size, hipMemcpyHostToDevice, stream));
+
+      // to release the host buffer in async
+      HIP_CALL_CHECK(hipLaunchHostFunc(
+          stream,
+          [](void* ud) {
+            ck_tile::pinned_host_releaser::instance().enqueue(ud);
+          },
+          host_buf));
+
+      if (FmhaBwdDQDKDVKernel::NeedsZeroDqAcc()) {
+        HIP_CALL_CHECK(
+            hipMemsetAsync(gpu_buf + host_ws_size, 0, device_ws_size, stream));
+      };
+
+      param.workspace_ptr = reinterpret_cast<uint8_t*>(gpu_buf);
+    } else {
+      auto host_ws_size =
+          FmhaBwdDQDKDVKernel::GetWorkspaceHostSize(param.num_batches);
+
+      const size_t seqstart_bytes = sizeof(int) * (param.num_batches + 1);
+      const size_t pin_total = 2 * seqstart_bytes + host_ws_size;
+      char* pin_buf;
+
+      HIP_CALL_CHECK(hipHostMalloc(&pin_buf, pin_total));
+
+      int* pin_q = reinterpret_cast<int*>(pin_buf);
+      int* pin_k = reinterpret_cast<int*>(pin_buf + seqstart_bytes);
+      void* pin_w = pin_buf + 2 * seqstart_bytes;
+
+      // to prepare the seqstart_q_host[] and seqstart_k_host[] in async
+      HIP_CALL_CHECK(hipMemcpyAsync(
+          pin_q,
+          param.seqstart_q_dev_ptr,
+          seqstart_bytes,
+          hipMemcpyDeviceToHost,
+          stream));
+      HIP_CALL_CHECK(hipMemcpyAsync(
+          pin_k,
+          param.seqstart_k_dev_ptr,
+          seqstart_bytes,
+          hipMemcpyDeviceToHost,
+          stream));
+
+      struct PrepareCtx {
+        void* pin_w;
+        int* pin_q;
+        int* pin_k;
+        int batch;
+        int hdim_q;
+        int nhead_q;
+      };
+      auto* ctx = new PrepareCtx{
+          pin_w, pin_q, pin_k, param.num_batches, param.K, param.Hq};
+
+      // to construct the content in host workspace in async
+      HIP_CALL_CHECK(hipLaunchHostFunc(
+          stream,
+          [](void* ud) {
+            auto* c = static_cast<PrepareCtx*>(ud);
+            FmhaBwdDQDKDVKernel::PrepareWorkspaceHost(
+                c->pin_w,
+                c->batch,
+                c->hdim_q,
+                c->nhead_q,
+                0, // seqlen_q, unused in group mode
+                0, // seqlen_k unused in group mode
+                c->pin_q,
+                c->pin_k);
+            delete c;
+          },
+          ctx));
+
+      const size_t device_ws_size =
+          FmhaBwdDQDKDVKernel::GetWorkspaceDeviceSizeUpperBound(
+              param.num_batches,
+              param.K,
+              param.Hq,
+              param.M,
+              param.max_seqlen_k);
+      param.workspace_size = host_ws_size + device_ws_size;
+
+      char* gpu_buf;
+
+      HIP_CALL_CHECK(hipMallocAsync(&gpu_buf, param.workspace_size, stream));
+
+      // to transfer the content of host workspace to gpu in async
+      HIP_CALL_CHECK(hipMemcpyAsync(
+          gpu_buf, pin_w, host_ws_size, hipMemcpyHostToDevice, stream));
+
+      // to release the host buffer (include the seqstart_q/k_host[] and host
+      // workspace) in async
+      HIP_CALL_CHECK(hipLaunchHostFunc(
+          stream,
+          [](void* ud) {
+            ck_tile::pinned_host_releaser::instance().enqueue(ud);
+          },
+          pin_buf));
+
+      if (FmhaBwdDQDKDVKernel::NeedsZeroDqAcc())
+        HIP_CALL_CHECK(
+            hipMemsetAsync(gpu_buf + host_ws_size, 0, device_ws_size, stream));
+
+      param.workspace_ptr = reinterpret_cast<uint8_t*>(gpu_buf);
+    };
+
     const auto kargs = [&] {
       return FmhaBwdDQDKDVKernel::MakeKargsImpl(
           param.q_ptr,
@@ -238,10 +363,11 @@ struct grouped_backward_mask_bias_dropout_dispatch {
           param.grad_out_ptr,
           param.dot_out_ptr,
           nullptr, // randval_ptr
+          nullptr, // dq_ptr, only used for QrQtrDor pipeline
           param.grad_k_ptr,
           param.grad_v_ptr,
           param.grad_bias_ptr,
-          NeedConvertGradQ ? param.grad_q_f32_ptr : param.grad_q_ptr,
+          param.workspace_ptr,
           param.seqstart_q_dev_ptr,
           param.seqstart_k_dev_ptr,
           nullptr, // seqlen_q_ptr, most recently added kernel argument
@@ -261,7 +387,7 @@ struct grouped_backward_mask_bias_dropout_dispatch {
           param.attn_bias_strides[1],
           0, // stride_randval
           param.grad_out_strides[0],
-          NeedConvertGradQ ? param.grad_q_f32_strides[0] : param.q_strides[0],
+          0, // stride_dq, // only used for QrQtrDor pipeline
           param.grad_k_strides[0],
           param.grad_v_strides[0],
           param.attn_bias_strides[1], // assume grad_bias has same strides as
@@ -274,12 +400,11 @@ struct grouped_backward_mask_bias_dropout_dispatch {
           0, // nhead_stride_randval
           param.grad_out_strides[1],
           param.lsed_strides[0], // assume lse/dot is in HM contiguous layout
-          NeedConvertGradQ ? param.grad_q_f32_strides[1] : param.q_strides[1],
+          0, // nhead_stride_dq, // only used for QrQtrDor pipeline
           param.grad_k_strides[1],
           param.grad_v_strides[1],
           param.attn_bias_strides[0], // assume grad_bias has same strides as
                                       // bias
-          0, // split_stride_dq_acc
           (param.window_size > 0) ? param.window_size - 1
                                   : -1, // window_left_size
           (param.custom_mask_type == 0) ? -1 : 0, // window_right_size
@@ -305,8 +430,10 @@ struct grouped_backward_mask_bias_dropout_dispatch {
       hipStream_t stream) {
     const auto kargs = [&] {
       return FmhaBwdConvertQGradKernel::MakeKargs(
-          param.grad_q_f32_ptr,
+          param.workspace_ptr,
           param.grad_q_ptr,
+          param.num_batches,
+          param.Hq,
           param.seqstart_q_dev_ptr,
           param.seqstart_k_dev_ptr,
           nullptr, // seqlen_q_ptr, most recently added kernel argument
@@ -315,10 +442,7 @@ struct grouped_backward_mask_bias_dropout_dispatch {
           nullptr, // cu_seqlen_k_ptr, most recently added kernel argument
           param.K, // headdim of q/k
           param.q_strides[0],
-          param.grad_q_f32_strides[0],
-          param.q_strides[1],
-          param.grad_q_f32_strides[1],
-          0); // split_stride_dq_acc, not used
+          param.q_strides[1]);
     }();
 
     dim3 kGridSize = FmhaBwdConvertQGradKernel::GridSize(
@@ -331,6 +455,10 @@ struct grouped_backward_mask_bias_dropout_dispatch {
         ck_tile::stream_config{stream, false},
         ck_tile::make_kernel<kBlockPerCu>(
             FmhaBwdConvertQGradKernel{}, kGridSize, kBlockSize, 0, kargs));
+
+    if (param.workspace_size > 0) {
+      HIP_CALL_CHECK(hipFreeAsync(param.workspace_ptr, stream));
+    };
   }
 };
 

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_params.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_fmha_params.h
@@ -197,6 +197,12 @@ struct BatchedBackwardParams {
   // BHM mode lengths, completely contiguous
   const void* logsumexp_ptr;
   void* dot_out_ptr;
+
+  // workspace ptr need not be set by the API users, it is set by intermediate
+  // layer codes before launching the fmha bwd kernel and freed aftre launching
+  // the convertDq kernel
+  int workspace_size;
+  uint8_t* workspace_ptr;
 };
 
 struct GroupedBackwardParams {
@@ -215,6 +221,9 @@ struct GroupedBackwardParams {
   void* seqstart_k_dev_ptr;
   void* seqlen_k_dev_ptr;
 
+  int* seqstart_q_host_ptr;
+  int* seqstart_k_host_ptr;
+
   float scale;
   bool has_attn_bias;
   bool bias_has_grad;
@@ -232,9 +241,6 @@ struct GroupedBackwardParams {
 
   std::array<int, 3> grad_k_strides;
   std::array<int, 3> grad_v_strides;
-
-  // assume grad_q has same strides as q, but grad_q_f32 can be different
-  std::array<int, 3> grad_q_f32_strides;
 
   // HM mode strides, completely contiguous, unpadded layout where M is
   // concatten total seqlen_q for all batches
@@ -255,8 +261,6 @@ struct GroupedBackwardParams {
   void* grad_v_ptr;
   void* grad_bias_ptr;
 
-  void* grad_q_f32_ptr;
-
   float dropout_prob;
   int64_t philox_seed;
   int64_t philox_offset;
@@ -264,4 +268,10 @@ struct GroupedBackwardParams {
   // BHM mode lengths, completely contiguous
   const void* logsumexp_ptr;
   void* dot_out_ptr;
+
+  // workspace ptr need not be set by the API users, it is set by intermediate
+  // layer codes before launching the fmha bwd kernel and freed aftre launching
+  // the convertDq kernel
+  int workspace_size;
+  uint8_t* workspace_ptr;
 };

--- a/xformers/csrc/attention/hip_fmha/ck_tiled_rand_uniform_kernel.h
+++ b/xformers/csrc/attention/hip_fmha/ck_tiled_rand_uniform_kernel.h
@@ -11,8 +11,17 @@
 
 template <typename RandValOutputDataType, bool kIsGroupMode>
 struct FmhaRandUniformKernel {
-  using BlockTile = ck_tile::sequence<128, 64, 32>;
+  // M/N tile size should be a multiplier of 32
+  static constexpr ck_tile::index_t kMPerBlock = 128;
+  static constexpr ck_tile::index_t kNPerBlock = 64;
+
+  using BlockTile = ck_tile::sequence<kMPerBlock, kNPerBlock, 32>;
+#if defined(__gfx11__) || defined(__gfx12__)
+  using WarpTile = ck_tile::sequence<16, 16, 16>;
+#else
+  // either 32x32 or 16x16 warp-gemm is ok for wave64
   using WarpTile = ck_tile::sequence<32, 32, 8>;
+#endif
   using BlockWarps = ck_tile::sequence<4, 1, 1>;
 
   using BlockGemmTileShape =
@@ -32,8 +41,26 @@ struct FmhaRandUniformKernel {
         kBlockSize,
         BlockGemmTileShape>;
 
-    // using the default policy, which use M32xN32xK8 warp_tile
-    return ck_tile::BlockGemmARegBSmemCRegV2<BlockGemmProblem_>{};
+    auto warp_gemm = ck_tile::WarpGemmDispatcher<
+        ck_tile::fp16_t,
+        ck_tile::fp16_t,
+        float,
+        WarpTile::at(number<0>{}),
+        WarpTile::at(number<1>{}),
+        WarpTile::at(number<2>{}),
+        false,
+        false,
+        false>{};
+
+    using BlockGemmPolicy = BlockGemmARegBSmemCRegV2CustomPolicy<
+        ck_tile::fp16_t,
+        ck_tile::fp16_t,
+        float,
+        BlockWarps,
+        decltype(warp_gemm)>;
+
+    return ck_tile::
+        BlockGemmARegBSmemCRegV2<BlockGemmProblem_, BlockGemmPolicy>{};
   };
 
   using BlockGemm = decltype(GetBlockGemm());
@@ -42,11 +69,6 @@ struct FmhaRandUniformKernel {
 
   static constexpr bool kPadSeqLenQ = true;
   static constexpr bool kPadSeqLenK = true;
-
-  using BlockGemmShape =
-      ck_tile::remove_cvref_t<typename BlockGemm::BlockGemmShape>;
-  static constexpr ck_tile::index_t kMPerBlock = BlockGemmShape::kM;
-  static constexpr ck_tile::index_t kNPerBlock = BlockGemmShape::kN;
 
   // kargs use aggregate initializer, so no constructor will provided
   // use inheritance to minimize karg size
@@ -172,7 +194,10 @@ struct FmhaRandUniformKernel {
   }
 
   __host__ static constexpr auto BlockSize() {
-    return dim3(kBlockSize);
+    if (ck_tile::is_wave32())
+      return dim3(kBlockSize / ck_tile::get_warp_size() * 32);
+    else
+      return dim3(kBlockSize);
   }
 
   __device__ static constexpr ck_tile::index_t GetSmemSize() {
@@ -182,104 +207,27 @@ struct FmhaRandUniformKernel {
 
   template <typename RandValDramBlockWindowTmp>
   __device__ void main_loop(
-      const Kargs& kargs,
-      const ck_tile::philox& ph,
+      const MyBlockDropout& dropout,
       void* randval_smem_ptr,
+      const ck_tile::index_t num_total_loop,
       RandValDramBlockWindowTmp& randval_dram_block_window_tmp) const {
-    using namespace ck_tile;
-
     auto randval_dram_window = MyBlockDropout::MakeRandvalDramWindow<BlockGemm>(
         randval_dram_block_window_tmp, 0);
 
-    const auto num_total_loop =
-        ck_tile::integer_divide_ceil(kargs.seqlen_k, kNPerBlock);
-    index_t i_total_loops = 0;
+    ck_tile::index_t i_total_loops = 0;
+
+    auto null_tile_window =
+        ck_tile::make_null_tile_window(ck_tile::make_tuple());
 
     do {
-      constexpr auto config = BlockGemm::Policy::template GetWarpGemmMWarpNWarp<
-          typename BlockGemm::Problem>();
-      using WG = remove_cvref_t<decltype(config.template at<0>())>;
-      constexpr index_t MWarp = config.template at<1>();
-      constexpr index_t NWarp = config.template at<2>();
-      constexpr index_t kMPerStep = MWarp * WG::kM;
-      constexpr index_t kNPerStep = NWarp * WG::kN;
+      auto seq_offset = i_total_loops * kNPerBlock;
 
-      // randval tile in LDS
-      auto randval_lds = make_tensor_view<address_space_enum::lds>(
-          reinterpret_cast<uint8_t*>(randval_smem_ptr),
-          MyBlockDropout::MakeRandValLdsBlockDescriptor<BlockGemm>());
-
-      auto randval_lds_window = make_tile_window(
-          randval_lds,
-          MyBlockDropout::MakeRandValLdsBlockDescriptor<BlockGemm>()
-              .get_lengths(),
-          {0, 0});
-
-      // register distribute
-      auto randval_dist_generated = make_static_distributed_tensor<uint8_t>(
-          MyBlockDropout::MakeRandValTileDistribution<BlockGemm>());
-
-      static_assert(randval_dist_generated.kThreadElementSpaceSize == 16);
-
-      auto randval_lds_read_window = make_tile_window(
-          randval_lds_window.get_bottom_tensor_view(),
-          randval_lds_window.get_window_lengths(),
-          randval_lds_window.get_window_origin(),
-          MyBlockDropout::MakeRandValLdsShuffleTileDistribution<BlockGemm>());
-
-      const int start_m0_idx =
-          randval_dram_window.get_window_origin().at(number<0>{});
-      const int start_n0_idx = i_total_loops * kNPerBlock;
-
-      static_for<0, kMPerBlock / kMPerStep, 1>{}([&](auto i_m0) {
-        static_for<0, kNPerBlock / kNPerStep, 1>{}([&](auto i_n0) {
-          const auto [block_row_start, block_col_start] = [&]() {
-            if constexpr (MWarp > 1) {
-              int block_row_start_ =
-                  (start_m0_idx / WG::kM) + (i_m0 * MWarp) + get_warp_id();
-              int block_col_start_ = start_n0_idx / WG::kN + i_n0;
-              return make_tuple(block_row_start_, block_col_start_);
-            } else {
-              int block_row_start_ = (start_m0_idx / WG::kM) + i_m0;
-              int block_col_start_ =
-                  (start_n0_idx / WG::kN) + (i_n0 * NWarp) + get_warp_id();
-              return make_tuple(block_row_start_, block_col_start_);
-            };
-          }();
-
-          uint2 rowcol = make_uint2(block_row_start, block_col_start);
-
-          // generate random number
-          uint8_t random_uint8_t[16];
-          ph.get_random_16x8(
-              random_uint8_t, reinterpret_cast<unsigned long long&>(rowcol));
-
-          constexpr auto randval_dist_generated_spans =
-              decltype(randval_dist_generated)::get_distributed_spans();
-          int i_random_idx = 0;
-          sweep_tile_span(
-              randval_dist_generated_spans[number<0>{}], [&](auto idx0) {
-                sweep_tile_span(
-                    randval_dist_generated_spans[number<1>{}], [&](auto idx1) {
-                      constexpr auto i_j_idx = make_tuple(idx0, idx1);
-                      randval_dist_generated(i_j_idx) =
-                          random_uint8_t[i_random_idx++];
-                    });
-              });
-          // save to LDS
-          store_tile(randval_lds_window, randval_dist_generated);
-          block_sync_lds();
-          // read from LDS to register
-          auto randval = load_tile(randval_lds_read_window);
-          // save to Global
-          const auto randval_store = cast_tile<RandValOutputDataType>(randval);
-          store_tile(randval_dram_window, randval_store);
-          move_tile_window(randval_dram_window, {0, kNPerStep});
-        });
-        move_tile_window(randval_dram_window, {kMPerStep, -kNPerBlock});
-      });
-
-      move_tile_window(randval_dram_window, {-kMPerBlock, kNPerBlock});
+      // randval_dram_window is moved inside BlockDropout::Run()
+      dropout.template Run<BlockGemm, float, RandValOutputDataType>(
+          reinterpret_cast<char*>(randval_smem_ptr),
+          seq_offset,
+          null_tile_window,
+          randval_dram_window);
 
     } while (++i_total_loops < num_total_loop);
   }
@@ -350,11 +298,18 @@ struct FmhaRandUniformKernel {
     auto randval_dram_block_window_tmp =
         make_tile_window(randval_dram, randval_dram_window_lengths, {i_m0, 0});
 
-    ck_tile::philox ph(
+    MyBlockDropout dropout(
+        i_batch,
+        i_nhead,
+        kargs.num_heads,
         kargs.seed,
-        kargs.offset + (i_batch * kargs.num_heads + i_nhead) * get_warp_size() +
-            get_lane_id());
+        kargs.offset,
+        0.0f /*rp_undrop_, not used*/,
+        0 /*p_undrop_in_uint8_t, not used*/,
+        true);
 
-    main_loop(kargs, ph, smem_ptr, randval_dram_block_window_tmp);
+    const auto num_total_loop =
+        ck_tile::integer_divide_ceil(kargs.seqlen_k, kNPerBlock);
+    main_loop(dropout, smem_ptr, num_total_loop, randval_dram_block_window_tmp);
   }
 };


### PR DESCRIPTION
## What does this PR do?

1. Re-implement the random uniform kernel by completely calls and depends on the BlockDropout module, avoiding replicated codes and support both `32x32` and `16x16` WarpTile across CDNA3/CDNA4/RDNA3/RDNA4 architectures
2. Adapt to recent changes introduced in fmha_bwd_kernel in two ck_tile PRs

> https://github.com/ROCm/rocm-libraries/pull/6152
> https://github.com/ROCm/rocm-libraries/pull/7331

## Test/Verify

1.  #> pytest tests/test_mem_eff_attention.py::test_backward 
2. #>  pytest tests/test_mem_eff_attention.py::test_forward
3. #>  pytest tests/test_mem_eff_attention.py::test_dropout_ck

The three tests all completely passed on gfx942 and gfx950

